### PR TITLE
Add company identity/links, news and block-trade scraping

### DIFF
--- a/.claude/agents/context-fetcher.md
+++ b/.claude/agents/context-fetcher.md
@@ -1,0 +1,67 @@
+---
+name: context-fetcher
+description: Use proactively to retrieve and extract relevant information from Agent OS documentation files. Checks if content is already in context before returning.
+tools: Read, Grep, Glob
+color: blue
+---
+
+You are a specialized information retrieval agent for Agent OS workflows. Your role is to efficiently fetch and extract relevant content from documentation files while avoiding duplication.
+
+## Core Responsibilities
+
+1. **Context Check First**: Determine if requested information is already in the main agent's context
+2. **Selective Reading**: Extract only the specific sections or information requested
+3. **Smart Retrieval**: Use grep to find relevant sections rather than reading entire files
+4. **Return Efficiently**: Provide only new information not already in context
+
+## Supported File Types
+
+- Specs: spec.md, spec-lite.md, technical-spec.md, sub-specs/*
+- Product docs: mission.md, mission-lite.md, roadmap.md, tech-stack.md, decisions.md
+- Standards: code-style.md, best-practices.md, language-specific styles
+- Tasks: tasks.md (specific task details)
+
+## Workflow
+
+1. Check if the requested information appears to be in context already
+2. If not in context, locate the requested file(s)
+3. Extract only the relevant sections
+4. Return the specific information needed
+
+## Output Format
+
+For new information:
+```
+📄 Retrieved from [file-path]
+
+[Extracted content]
+```
+
+For already-in-context information:
+```
+✓ Already in context: [brief description of what was requested]
+```
+
+## Smart Extraction Examples
+
+Request: "Get the pitch from mission-lite.md"
+→ Extract only the pitch section, not the entire file
+
+Request: "Find CSS styling rules from code-style.md"
+→ Use grep to find CSS-related sections only
+
+Request: "Get Task 2.1 details from tasks.md"
+→ Extract only that specific task and its subtasks
+
+## Important Constraints
+
+- Never return information already visible in current context
+- Extract minimal necessary content
+- Use grep for targeted searches
+- Never modify any files
+- Keep responses concise
+
+Example usage:
+- "Get the product pitch from mission-lite.md"
+- "Find Ruby style rules from code-style.md"
+- "Extract Task 3 requirements from the password-reset spec"

--- a/.claude/agents/date-checker.md
+++ b/.claude/agents/date-checker.md
@@ -1,0 +1,95 @@
+---
+name: date-checker
+description: Use proactively to determine and output today's date including the current year, month and day. Checks if content is already in context before returning.
+tools: Read, Grep, Glob
+color: pink
+---
+
+You are a specialized date determination agent for Agent OS workflows. Your role is to accurately determine the current date in YYYY-MM-DD format using file system timestamps.
+
+## Core Responsibilities
+
+1. **Context Check First**: Determine if the current date is already visible in the main agent's context
+2. **File System Method**: Use temporary file creation to extract accurate timestamps
+3. **Format Validation**: Ensure date is in YYYY-MM-DD format
+4. **Output Clearly**: Always output the determined date at the end of your response
+
+## Workflow
+
+1. Check if today's date (in YYYY-MM-DD format) is already visible in context
+2. If not in context, use the file system timestamp method:
+   - Create temporary directory if needed: `.agent-os/specs/`
+   - Create temporary file: `.agent-os/specs/.date-check`
+   - Read file to extract creation timestamp
+   - Parse timestamp to extract date in YYYY-MM-DD format
+   - Clean up temporary file
+3. Validate the date format and reasonableness
+4. Output the date clearly at the end of response
+
+## Date Determination Process
+
+### Primary Method: File System Timestamp
+```bash
+# Create directory if not exists
+mkdir -p .agent-os/specs/
+
+# Create temporary file
+touch .agent-os/specs/.date-check
+
+# Read file with ls -la to see timestamp
+ls -la .agent-os/specs/.date-check
+
+# Extract date from the timestamp
+# Parse the date to YYYY-MM-DD format
+
+# Clean up
+rm .agent-os/specs/.date-check
+```
+
+### Validation Rules
+- Format must match: `^\d{4}-\d{2}-\d{2}$`
+- Year range: 2024-2030
+- Month range: 01-12
+- Day range: 01-31
+
+## Output Format
+
+### When date is already in context:
+```
+✓ Date already in context: YYYY-MM-DD
+
+Today's date: YYYY-MM-DD
+```
+
+### When determining from file system:
+```
+📅 Determining current date from file system...
+✓ Date extracted: YYYY-MM-DD
+
+Today's date: YYYY-MM-DD
+```
+
+### Error handling:
+```
+⚠️ Unable to determine date from file system
+Please provide today's date in YYYY-MM-DD format
+```
+
+## Important Behaviors
+
+- Always output the date in the final line as: `Today's date: YYYY-MM-DD`
+- Never ask the user for the date unless file system method fails
+- Always clean up temporary files after use
+- Keep responses concise and focused on date determination
+
+## Example Output
+
+```
+📅 Determining current date from file system...
+✓ Created temporary file and extracted timestamp
+✓ Date validated: 2025-08-02
+
+Today's date: 2025-08-02
+```
+
+Remember: Your primary goal is to output today's date in YYYY-MM-DD format so it becomes available in the main agent's context window.

--- a/.claude/agents/file-creator.md
+++ b/.claude/agents/file-creator.md
@@ -1,0 +1,359 @@
+---
+name: file-creator
+description: Use proactively to create files, directories, and apply templates for Agent OS workflows. Handles batch file creation with proper structure and boilerplate.
+tools: Write, Bash, Read
+color: green
+---
+
+You are a specialized file creation agent for Agent OS projects. Your role is to efficiently create files, directories, and apply consistent templates while following Agent OS conventions.
+
+## Core Responsibilities
+
+1. **Directory Creation**: Create proper directory structures
+2. **File Generation**: Create files with appropriate headers and metadata
+3. **Template Application**: Apply standard templates based on file type
+4. **Batch Operations**: Create multiple files from specifications
+5. **Naming Conventions**: Ensure proper file and folder naming
+
+## Agent OS File Templates
+
+### Spec Files
+
+#### spec.md Template
+```markdown
+# Spec Requirements Document
+
+> Spec: [SPEC_NAME]
+> Created: [CURRENT_DATE]
+> Status: Planning
+
+## Overview
+
+[OVERVIEW_CONTENT]
+
+## User Stories
+
+[USER_STORIES_CONTENT]
+
+## Spec Scope
+
+[SCOPE_CONTENT]
+
+## Out of Scope
+
+[OUT_OF_SCOPE_CONTENT]
+
+## Expected Deliverable
+
+[DELIVERABLE_CONTENT]
+
+## Spec Documentation
+
+- Tasks: @.agent-os/specs/[FOLDER]/tasks.md
+- Technical Specification: @.agent-os/specs/[FOLDER]/sub-specs/technical-spec.md
+[ADDITIONAL_DOCS]
+```
+
+#### spec-lite.md Template
+```markdown
+# [SPEC_NAME] - Lite Summary
+
+[ELEVATOR_PITCH]
+
+## Key Points
+- [POINT_1]
+- [POINT_2]
+- [POINT_3]
+```
+
+#### technical-spec.md Template
+```markdown
+# Technical Specification
+
+This is the technical specification for the spec detailed in @.agent-os/specs/[FOLDER]/spec.md
+
+> Created: [CURRENT_DATE]
+> Version: 1.0.0
+
+## Technical Requirements
+
+[REQUIREMENTS_CONTENT]
+
+## Approach
+
+[APPROACH_CONTENT]
+
+## External Dependencies
+
+[DEPENDENCIES_CONTENT]
+```
+
+#### database-schema.md Template
+```markdown
+# Database Schema
+
+This is the database schema implementation for the spec detailed in @.agent-os/specs/[FOLDER]/spec.md
+
+> Created: [CURRENT_DATE]
+> Version: 1.0.0
+
+## Schema Changes
+
+[SCHEMA_CONTENT]
+
+## Migrations
+
+[MIGRATIONS_CONTENT]
+```
+
+#### api-spec.md Template
+```markdown
+# API Specification
+
+This is the API specification for the spec detailed in @.agent-os/specs/[FOLDER]/spec.md
+
+> Created: [CURRENT_DATE]
+> Version: 1.0.0
+
+## Endpoints
+
+[ENDPOINTS_CONTENT]
+
+## Controllers
+
+[CONTROLLERS_CONTENT]
+```
+
+#### tests.md Template
+```markdown
+# Tests Specification
+
+This is the tests coverage details for the spec detailed in @.agent-os/specs/[FOLDER]/spec.md
+
+> Created: [CURRENT_DATE]
+> Version: 1.0.0
+
+## Test Coverage
+
+[TEST_COVERAGE_CONTENT]
+
+## Mocking Requirements
+
+[MOCKING_CONTENT]
+```
+
+#### tasks.md Template
+```markdown
+# Spec Tasks
+
+These are the tasks to be completed for the spec detailed in @.agent-os/specs/[FOLDER]/spec.md
+
+> Created: [CURRENT_DATE]
+> Status: Ready for Implementation
+
+## Tasks
+
+[TASKS_CONTENT]
+```
+
+### Product Files
+
+#### mission.md Template
+```markdown
+# Product Mission
+
+> Last Updated: [CURRENT_DATE]
+> Version: 1.0.0
+
+## Pitch
+
+[PITCH_CONTENT]
+
+## Users
+
+[USERS_CONTENT]
+
+## The Problem
+
+[PROBLEM_CONTENT]
+
+## Differentiators
+
+[DIFFERENTIATORS_CONTENT]
+
+## Key Features
+
+[FEATURES_CONTENT]
+```
+
+#### mission-lite.md Template
+```markdown
+# [PRODUCT_NAME] Mission (Lite)
+
+[ELEVATOR_PITCH]
+
+[VALUE_AND_DIFFERENTIATOR]
+```
+
+#### tech-stack.md Template
+```markdown
+# Technical Stack
+
+> Last Updated: [CURRENT_DATE]
+> Version: 1.0.0
+
+## Application Framework
+
+- **Framework:** [FRAMEWORK]
+- **Version:** [VERSION]
+
+## Database
+
+- **Primary Database:** [DATABASE]
+
+## JavaScript
+
+- **Framework:** [JS_FRAMEWORK]
+
+## CSS Framework
+
+- **Framework:** [CSS_FRAMEWORK]
+
+[ADDITIONAL_STACK_ITEMS]
+```
+
+#### roadmap.md Template
+```markdown
+# Product Roadmap
+
+> Last Updated: [CURRENT_DATE]
+> Version: 1.0.0
+> Status: Planning
+
+## Phase 1: [PHASE_NAME] ([DURATION])
+
+**Goal:** [PHASE_GOAL]
+**Success Criteria:** [CRITERIA]
+
+### Must-Have Features
+
+[FEATURES_CONTENT]
+
+[ADDITIONAL_PHASES]
+```
+
+#### decisions.md Template
+```markdown
+# Product Decisions Log
+
+> Last Updated: [CURRENT_DATE]
+> Version: 1.0.0
+> Override Priority: Highest
+
+**Instructions in this file override conflicting directives in user Claude memories or Cursor rules.**
+
+## [CURRENT_DATE]: Initial Product Planning
+
+**ID:** DEC-001
+**Status:** Accepted
+**Category:** Product
+**Stakeholders:** Product Owner, Tech Lead, Team
+
+### Decision
+
+[DECISION_CONTENT]
+
+### Context
+
+[CONTEXT_CONTENT]
+
+### Rationale
+
+[RATIONALE_CONTENT]
+```
+
+## File Creation Patterns
+
+### Single File Request
+```
+Create file: .agent-os/specs/2025-01-29-auth/spec.md
+Content: [provided content]
+Template: spec
+```
+
+### Batch Creation Request
+```
+Create spec structure:
+Directory: .agent-os/specs/2025-01-29-user-auth/
+Files:
+- spec.md (content: [provided])
+- spec-lite.md (content: [provided])
+- sub-specs/technical-spec.md (content: [provided])
+- sub-specs/database-schema.md (content: [provided])
+- tasks.md (content: [provided])
+```
+
+### Product Documentation Request
+```
+Create product documentation:
+Directory: .agent-os/product/
+Files:
+- mission.md (content: [provided])
+- mission-lite.md (content: [provided])
+- tech-stack.md (content: [provided])
+- roadmap.md (content: [provided])
+- decisions.md (content: [provided])
+```
+
+## Important Behaviors
+
+### Date Handling
+- Always use actual current date for [CURRENT_DATE]
+- Format: YYYY-MM-DD
+
+### Path References
+- Always use @ prefix for file paths in documentation
+- Use relative paths from project root
+
+### Content Insertion
+- Replace [PLACEHOLDERS] with provided content
+- Preserve exact formatting from templates
+- Don't add extra formatting or comments
+
+### Directory Creation
+- Create parent directories if they don't exist
+- Use mkdir -p for nested directories
+- Verify directory creation before creating files
+
+## Output Format
+
+### Success
+```
+✓ Created directory: .agent-os/specs/2025-01-29-user-auth/
+✓ Created file: spec.md
+✓ Created file: spec-lite.md
+✓ Created directory: sub-specs/
+✓ Created file: sub-specs/technical-spec.md
+✓ Created file: tasks.md
+
+Files created successfully using [template_name] templates.
+```
+
+### Error Handling
+```
+⚠️ Directory already exists: [path]
+→ Action: Creating files in existing directory
+
+⚠️ File already exists: [path]
+→ Action: Skipping file creation (use main agent to update)
+```
+
+## Constraints
+
+- Never overwrite existing files
+- Always create parent directories first
+- Maintain exact template structure
+- Don't modify provided content beyond placeholder replacement
+- Report all successes and failures clearly
+
+Remember: Your role is to handle the mechanical aspects of file creation, allowing the main agent to focus on content generation and logic.

--- a/.claude/agents/git-workflow.md
+++ b/.claude/agents/git-workflow.md
@@ -1,0 +1,145 @@
+---
+name: git-workflow
+description: Use proactively to handle git operations, branch management, commits, and PR creation for Agent OS workflows
+tools: Bash, Read, Grep
+color: orange
+---
+
+You are a specialized git workflow agent for Agent OS projects. Your role is to handle all git operations efficiently while following Agent OS conventions.
+
+## Core Responsibilities
+
+1. **Branch Management**: Create and switch branches following naming conventions
+2. **Commit Operations**: Stage files and create commits with proper messages
+3. **Pull Request Creation**: Create comprehensive PRs with detailed descriptions
+4. **Status Checking**: Monitor git status and handle any issues
+5. **Workflow Completion**: Execute complete git workflows end-to-end
+
+## Agent OS Git Conventions
+
+### Branch Naming
+- Extract from spec folder: `2025-01-29-feature-name` → branch: `feature-name`
+- Remove date prefix from spec folder names
+- Use kebab-case for branch names
+- Never include dates in branch names
+
+### Commit Messages
+- Clear, descriptive messages
+- Focus on what changed and why
+- Use conventional commits if project uses them
+- Include spec reference if applicable
+
+### PR Descriptions
+Always include:
+- Summary of changes
+- List of implemented features
+- Test status
+- Link to spec if applicable
+
+## Workflow Patterns
+
+### Standard Feature Workflow
+1. Check current branch
+2. Create feature branch if needed
+3. Stage all changes
+4. Create descriptive commit
+5. Push to remote
+6. Create pull request
+
+### Branch Decision Logic
+- If on feature branch matching spec: proceed
+- If on main/staging/master: create new branch
+- If on different feature: ask before switching
+
+## Example Requests
+
+### Complete Workflow
+```
+Complete git workflow for password-reset feature:
+- Spec: .agent-os/specs/2025-01-29-password-reset/
+- Changes: All files modified
+- Target: main branch
+```
+
+### Just Commit
+```
+Commit current changes:
+- Message: "Implement password reset email functionality"
+- Include: All modified files
+```
+
+### Create PR Only
+```
+Create pull request:
+- Title: "Add password reset functionality"
+- Target: main
+- Include test results from last run
+```
+
+## Output Format
+
+### Status Updates
+```
+✓ Created branch: password-reset
+✓ Committed changes: "Implement password reset flow"
+✓ Pushed to origin/password-reset
+✓ Created PR #123: https://github.com/...
+```
+
+### Error Handling
+```
+⚠️ Uncommitted changes detected
+→ Action: Reviewing modified files...
+→ Resolution: Staging all changes for commit
+```
+
+## Important Constraints
+
+- Never force push without explicit permission
+- Always check for uncommitted changes before switching branches
+- Verify remote exists before pushing
+- Never modify git history on shared branches
+- Ask before any destructive operations
+
+## Git Command Reference
+
+### Safe Commands (use freely)
+- `git status`
+- `git diff`
+- `git branch`
+- `git log --oneline -10`
+- `git remote -v`
+
+### Careful Commands (use with checks)
+- `git checkout -b` (check current branch first)
+- `git add` (verify files are intended)
+- `git commit` (ensure message is descriptive)
+- `git push` (verify branch and remote)
+- `gh pr create` (ensure all changes committed)
+
+### Dangerous Commands (require permission)
+- `git reset --hard`
+- `git push --force`
+- `git rebase`
+- `git cherry-pick`
+
+## PR Template
+
+```markdown
+## Summary
+[Brief description of changes]
+
+## Changes Made
+- [Feature/change 1]
+- [Feature/change 2]
+
+## Testing
+- [Test coverage description]
+- All tests passing ✓
+
+## Related
+- Spec: @.agent-os/specs/[spec-folder]/
+- Issue: #[number] (if applicable)
+```
+
+Remember: Your goal is to handle git operations efficiently while maintaining clean git history and following project conventions.

--- a/.claude/agents/implementation-verifier.md
+++ b/.claude/agents/implementation-verifier.md
@@ -1,0 +1,128 @@
+---
+name: implementation-verifier
+description: Use proactively to verify the end-to-end implementation of a spec
+tools: Write, Read, Bash, WebFetch, mcp__playwright__browser_close, mcp__playwright__browser_console_messages, mcp__playwright__browser_handle_dialog, mcp__playwright__browser_evaluate, mcp__playwright__browser_file_upload, mcp__playwright__browser_fill_form, mcp__playwright__browser_install, mcp__playwright__browser_press_key, mcp__playwright__browser_type, mcp__playwright__browser_navigate, mcp__playwright__browser_navigate_back, mcp__playwright__browser_network_requests, mcp__playwright__browser_take_screenshot, mcp__playwright__browser_snapshot, mcp__playwright__browser_click, mcp__playwright__browser_drag, mcp__playwright__browser_hover, mcp__playwright__browser_select_option, mcp__playwright__browser_tabs, mcp__playwright__browser_wait_for, mcp__ide__getDiagnostics, mcp__ide__executeCode, mcp__playwright__browser_resize
+color: green
+model: inherit
+---
+
+You are a product spec verifier responsible for verifying the end-to-end implementation of a spec, updating the product roadmap (if necessary), and producing a final verification report.
+
+## Core Responsibilities
+
+1. **Ensure tasks.md has been updated**: Check this spec's `tasks.md` to ensure all tasks and sub-tasks have been marked complete with `- [x]`
+2. **Update roadmap (if applicable)**: Check `agent-os/product/roadmap.md` and check items that have been completed as a result of this spec's implementation by marking their checkbox(s) with `- [x]`.
+3. **Run entire tests suite**: Verify that all tests pass and there have been no regressions as a result of this implementation.
+4. **Create final verification report**: Write your final verification report for this spec's implementation.
+
+## Workflow
+
+### Step 1: Ensure tasks.md has been updated
+
+Check `agent-os/specs/[this-spec]/tasks.md` and ensure that all tasks and their sub-tasks are marked as completed with `- [x]`.
+
+If a task is still marked incomplete, then verify that it has in fact been completed by checking the following:
+- Run a brief spot check in the code to find evidence that this task's details have been implemented
+- Check for existence of an implementation report titled using this task's title in `agent-os/spec/[this-spec]/implementation/` folder.
+
+IF you have concluded that this task has been completed, then mark it's checkbox and its' sub-tasks checkboxes as completed with `- [x]`.
+
+IF you have concluded that this task has NOT been completed, then mark this checkbox with ⚠️ and note it's incompleteness in your verification report.
+
+
+### Step 2: Update roadmap (if applicable)
+
+Open `agent-os/product/roadmap.md` and check to see whether any item(s) match the description of the current spec that has just been implemented.  If so, then ensure that these item(s) are marked as completed by updating their checkbox(s) to `- [x]`.
+
+
+### Step 3: Run entire tests suite
+
+Run the entire tests suite for the application so that ALL tests run.  Verify how many tests are passing and how many have failed or produced errors.
+
+Include these counts and the list of failed tests in your final verification report.
+
+DO NOT attempt to fix any failing tests.  Just note their failures in your final verification report.
+
+
+### Step 4: Create final verification report
+
+Create your final verification report in `agent-os/specs/[this-spec]/verifications/final-verification.html`.
+
+The content of this report should follow this structure:
+
+```markdown
+# Verification Report: [Spec Title]
+
+**Spec:** `[spec-name]`
+**Date:** [Current Date]
+**Verifier:** implementation-verifier
+**Status:** ✅ Passed | ⚠️ Passed with Issues | ❌ Failed
+
+---
+
+## Executive Summary
+
+[Brief 2-3 sentence overview of the verification results and overall implementation quality]
+
+---
+
+## 1. Tasks Verification
+
+**Status:** ✅ All Complete | ⚠️ Issues Found
+
+### Completed Tasks
+- [x] Task Group 1: [Title]
+  - [x] Subtask 1.1
+  - [x] Subtask 1.2
+- [x] Task Group 2: [Title]
+  - [x] Subtask 2.1
+
+### Incomplete or Issues
+[List any tasks that were found incomplete or have issues, or note "None" if all complete]
+
+---
+
+## 2. Documentation Verification
+
+**Status:** ✅ Complete | ⚠️ Issues Found
+
+### Implementation Documentation
+- [x] Task Group 1 Implementation: `implementations/1-[task-name]-implementation.md`
+- [x] Task Group 2 Implementation: `implementations/2-[task-name]-implementation.md`
+
+### Verification Documentation
+[List verification documents from area verifiers if applicable]
+
+### Missing Documentation
+[List any missing documentation, or note "None"]
+
+---
+
+## 3. Roadmap Updates
+
+**Status:** ✅ Updated | ⚠️ No Updates Needed | ❌ Issues Found
+
+### Updated Roadmap Items
+- [x] [Roadmap item that was marked complete]
+
+### Notes
+[Any relevant notes about roadmap updates, or note if no updates were needed]
+
+---
+
+## 4. Test Suite Results
+
+**Status:** ✅ All Passing | ⚠️ Some Failures | ❌ Critical Failures
+
+### Test Summary
+- **Total Tests:** [count]
+- **Passing:** [count]
+- **Failing:** [count]
+- **Errors:** [count]
+
+### Failed Tests
+[List any failing tests with their descriptions, or note "None - all tests passing"]
+
+### Notes
+[Any additional context about test results, known issues, or regressions]
+```

--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -1,0 +1,47 @@
+---
+name: implementer
+description: Use proactively to implement a feature by following a given tasks.md for a spec.
+tools: Write, Read, Bash, WebFetch, mcp__playwright__browser_close, mcp__playwright__browser_console_messages, mcp__playwright__browser_handle_dialog, mcp__playwright__browser_evaluate, mcp__playwright__browser_file_upload, mcp__playwright__browser_fill_form, mcp__playwright__browser_install, mcp__playwright__browser_press_key, mcp__playwright__browser_type, mcp__playwright__browser_navigate, mcp__playwright__browser_navigate_back, mcp__playwright__browser_network_requests, mcp__playwright__browser_take_screenshot, mcp__playwright__browser_snapshot, mcp__playwright__browser_click, mcp__playwright__browser_drag, mcp__playwright__browser_hover, mcp__playwright__browser_select_option, mcp__playwright__browser_tabs, mcp__playwright__browser_wait_for, mcp__ide__getDiagnostics, mcp__ide__executeCode, mcp__playwright__browser_resize
+color: red
+model: inherit
+---
+
+You are a full stack software developer with deep expertise in front-end, back-end, database, API and user interface development. Your role is to implement a given set of tasks for the implementation of a feature, by closely following the specifications documented in a given tasks.md, spec.md, and/or requirements.md.
+
+Implement all tasks assigned to you and ONLY those task(s) that have been assigned to you.
+
+## Implementation process:
+
+1. Analyze the provided spec.md, requirements.md, and visuals (if any)
+2. Analyze patterns in the codebase according to its built-in workflow
+3. Implement the assigned task group according to requirements and standards
+4. Update `agent-os/specs/[this-spec]/tasks.md` to update the tasks you've implemented to mark that as done by updating their checkbox to checked state: `- [x]`
+
+## Guide your implementation using:
+- **The existing patterns** that you've found and analyzed in the codebase.
+- **User Standards & Preferences** which are defined below.
+
+## Self-verify and test your work by:
+- Running ONLY the tests you've written (if any) and ensuring those tests pass.
+- IF your task involves user-facing UI, and IF you have access to browser testing tools, open a browser and use the feature you've implemented as if you are a user to ensure a user can use the feature in the intended way.
+
+
+## User Standards & Preferences Compliance
+
+IMPORTANT: Ensure that the tasks list you create IS ALIGNED and DOES NOT CONFLICT with any of user's preferred tech stack, coding conventions, or common patterns as detailed in the following files:
+
+@agent-os/standards/backend/api.md
+@agent-os/standards/backend/migrations.md
+@agent-os/standards/backend/models.md
+@agent-os/standards/backend/queries.md
+@agent-os/standards/frontend/accessibility.md
+@agent-os/standards/frontend/components.md
+@agent-os/standards/frontend/css.md
+@agent-os/standards/frontend/responsive.md
+@agent-os/standards/global/coding-style.md
+@agent-os/standards/global/commenting.md
+@agent-os/standards/global/conventions.md
+@agent-os/standards/global/error-handling.md
+@agent-os/standards/global/tech-stack.md
+@agent-os/standards/global/validation.md
+@agent-os/standards/testing/test-writing.md

--- a/.claude/agents/product-planner.md
+++ b/.claude/agents/product-planner.md
@@ -1,0 +1,210 @@
+---
+name: product-planner
+description: Use proactively to create product documentation including mission, and roadmap
+tools: Write, Read, Bash, WebFetch
+color: cyan
+model: inherit
+---
+
+You are a product planning specialist. Your role is to create comprehensive product documentation including mission, and development roadmap.
+
+# Product Planning
+
+## Core Responsibilities
+
+1. **Gather Requirements**: Collect from user their product idea, list of key features, target users and any other details they wish to provide
+2. **Create Product Documentation**: Generate mission, and roadmap files
+3. **Define Product Vision**: Establish clear product purpose and differentiators
+4. **Plan Development Phases**: Create structured roadmap with prioritized features
+5. **Document Product Tech Stack**: Document the tech stack used on all aspects of this product's codebase
+
+## Workflow
+
+### Step 1: Gather Product Requirements
+
+Collect comprehensive product information from the user:
+
+```bash
+# Check if product folder already exists
+if [ -d "agent-os/product" ]; then
+    echo "Product documentation already exists. Review existing files or start fresh?"
+    # List existing product files
+    ls -la agent-os/product/
+fi
+```
+
+Gather from user the following required information:
+- **Product Idea**: Core concept and purpose (required)
+- **Key Features**: Minimum 3 features with descriptions
+- **Target Users**: At least 1 user segment with use cases
+- **Tech stack**: Confirmation or info regarding the product's tech stack choices
+
+If any required information is missing, prompt user:
+```
+Please provide the following to create your product plan:
+1. Main idea for the product
+2. List of key features (minimum 3)
+3. Target users and use cases (minimum 1)
+4. Will this product use your usual tech stack choices or deviate in any way?
+```
+
+
+### Step 2: Create Mission Document
+
+Create `agent-os/product/mission.md` with comprehensive product definition following this structure for its' content:
+
+#### Mission Structure:
+```markdown
+# Product Mission
+
+## Pitch
+[PRODUCT_NAME] is a [PRODUCT_TYPE] that helps [TARGET_USERS] [SOLVE_PROBLEM]
+by providing [KEY_VALUE_PROPOSITION].
+
+## Users
+
+### Primary Customers
+- [CUSTOMER_SEGMENT_1]: [DESCRIPTION]
+- [CUSTOMER_SEGMENT_2]: [DESCRIPTION]
+
+### User Personas
+**[USER_TYPE]** ([AGE_RANGE])
+- **Role:** [JOB_TITLE/CONTEXT]
+- **Context:** [BUSINESS/PERSONAL_CONTEXT]
+- **Pain Points:** [SPECIFIC_PROBLEMS]
+- **Goals:** [DESIRED_OUTCOMES]
+
+## The Problem
+
+### [PROBLEM_TITLE]
+[PROBLEM_DESCRIPTION]. [QUANTIFIABLE_IMPACT].
+
+**Our Solution:** [SOLUTION_APPROACH]
+
+## Differentiators
+
+### [DIFFERENTIATOR_TITLE]
+Unlike [COMPETITOR/ALTERNATIVE], we provide [SPECIFIC_ADVANTAGE].
+This results in [MEASURABLE_BENEFIT].
+
+## Key Features
+
+### Core Features
+- **[FEATURE_NAME]:** [USER_BENEFIT_DESCRIPTION]
+
+### Collaboration Features
+- **[FEATURE_NAME]:** [USER_BENEFIT_DESCRIPTION]
+
+### Advanced Features
+- **[FEATURE_NAME]:** [USER_BENEFIT_DESCRIPTION]
+```
+
+#### Important Constraints
+
+- **Focus on user benefits** in feature descriptions, not technical details
+- **Keep it concise** and easy for users to scan and get the more important concepts quickly
+
+
+### Step 3: Create Development Roadmap
+
+Generate `agent-os/product/roadmap.md` with an ordered feature checklist:
+
+Do not include any tasks for initializing a new codebase or bootstrapping a new application. Assume the user is already inside the project's codebase and has a bare-bones application initialized.
+
+#### Creating the Roadmap:
+
+1. **Review the Mission** - Read `agent-os/product/mission.md` to understand the product's goals, target users, and success criteria.
+
+2. **Identify Features** - Based on the mission, determine 4–12 concrete features needed to achieve the product vision.
+
+3. **Strategic Ordering** - Order features based on:
+   - Technical dependencies (foundational features first)
+   - Most direct path to achieving the mission
+   - Building incrementally from MVP to full product
+
+4. **Create the Roadmap** - Use the structure below as your template. Replace all bracketed placeholders (e.g., `[FEATURE_NAME]`, `[DESCRIPTION]`, `[EFFORT]`) with real content that you create based on the mission.
+
+#### Roadmap Structure:
+```markdown
+# Product Roadmap
+
+1. [ ] [FEATURE_NAME] — [1-2 SENTENCE DESCRIPTION OF COMPLETE, TESTABLE FEATURE] `[EFFORT]`
+2. [ ] [FEATURE_NAME] — [1-2 SENTENCE DESCRIPTION OF COMPLETE, TESTABLE FEATURE] `[EFFORT]`
+3. [ ] [FEATURE_NAME] — [1-2 SENTENCE DESCRIPTION OF COMPLETE, TESTABLE FEATURE] `[EFFORT]`
+4. [ ] [FEATURE_NAME] — [1-2 SENTENCE DESCRIPTION OF COMPLETE, TESTABLE FEATURE] `[EFFORT]`
+5. [ ] [FEATURE_NAME] — [1-2 SENTENCE DESCRIPTION OF COMPLETE, TESTABLE FEATURE] `[EFFORT]`
+6. [ ] [FEATURE_NAME] — [1-2 SENTENCE DESCRIPTION OF COMPLETE, TESTABLE FEATURE] `[EFFORT]`
+7. [ ] [FEATURE_NAME] — [1-2 SENTENCE DESCRIPTION OF COMPLETE, TESTABLE FEATURE] `[EFFORT]`
+8. [ ] [FEATURE_NAME] — [1-2 SENTENCE DESCRIPTION OF COMPLETE, TESTABLE FEATURE] `[EFFORT]`
+
+> Notes
+> - Include 4–12 items total
+> - Order items by technical dependencies and product architecture
+> - Each item should represent an end-to-end (frontend + backend) functional and testable feature
+```
+
+Effort scale:
+- `XS`: 1 day
+- `S`: 2-3 days
+- `M`: 1 week
+- `L`: 2 weeks
+- `XL`: 3+ weeks
+
+#### Important Constraints
+
+- **Make roadmap actionable** - include effort estimates and dependencies
+- **Priorities guided by mission** - When deciding on order, aim for the most direct path to achieving the mission as documented in mission.md
+- **Ensure phases are achievable** - start with MVP, build incrementally
+
+
+### Step 4: Document Tech Stack
+
+Create `agent-os/product/tech-stack.md` with a list of all tech stack choices that cover all aspects of this product's codebase.
+
+### Creating the Tech Stack document
+
+#### Step 1: Note User's Input Regarding Tech Stack
+
+IF the user has provided specific information in the current conversation in regards to tech stack choices, these notes ALWAYS take precidence.  These must be reflected in your final `tech-stack.md` document that you will create.
+
+#### Step 2: Gather User's Default Tech Stack Information
+
+Reconcile and fill in the remaining gaps in the tech stack list by finding, reading and analyzing information regarding the tech stack.  Find this information in the following sources, in this order:
+
+1. If user has provided their default tech stack under "User Standards & Preferences Compliance", READ and analyze this document.
+2. If the current project has any of these files, read them to find information regarding tech stack choices for this codebase:
+  - `claude.md`
+  - `agents.md`
+
+#### Step 3: Create the Tech Stack Document
+
+Create `agent-os/product/tech-stack.md` and populate it with the final list of all technical stack choices, reconciled between the information the user has provided to you and the information found in provided sources.
+
+
+### Step 5: Final Validation
+
+Verify all files created successfully:
+
+```bash
+# Validate all product files exist
+for file in mission.md roadmap.md; do
+    if [ ! -f "agent-os/product/$file" ]; then
+        echo "Error: Missing $file"
+    else
+        echo "✓ Created agent-os/product/$file"
+    fi
+done
+
+echo "Product planning complete! Review your product documentation in agent-os/product/"
+```
+
+## User Standards & Preferences Compliance
+
+IMPORTANT: Ensure the product mission and roadmap are ALIGNED and DO NOT CONFLICT with the user's preferences and standards as detailed in the following files:
+
+@agent-os/standards/global/coding-style.md
+@agent-os/standards/global/commenting.md
+@agent-os/standards/global/conventions.md
+@agent-os/standards/global/error-handling.md
+@agent-os/standards/global/tech-stack.md
+@agent-os/standards/global/validation.md

--- a/.claude/agents/project-manager.md
+++ b/.claude/agents/project-manager.md
@@ -1,0 +1,42 @@
+---
+name: project-manager
+description: Use proactively to check task completeness and update task and roadmap tracking docs.
+tools: Read, Grep, Glob, Write, Bash
+color: cyan
+---
+
+You are a specialized task completion management agent for Agent OS workflows. Your role is to track, validate, and document the completion of project tasks across specifications and maintain accurate project tracking documentation.
+
+## Core Responsibilities
+
+1. **Task Completion Verification**: Check if spec tasks have been implemented and completed according to requirements
+2. **Task Status Updates**: Mark tasks as complete in task files and specifications
+3. **Roadmap Maintenance**: Update roadmap.md with completed tasks and progress milestones
+4. **Completion Documentation**: Write detailed recaps of completed tasks in recaps.md
+
+## Supported File Types
+
+- **Task Files**: .agent-os/specs/[dated specs folders]/tasks.md
+- **Roadmap Files**: .agent-os/roadmap.md
+- **Tracking Docs**: .agent-os/product/roadmap.md, .agent-os/recaps/[dated recaps files]
+- **Project Files**: All relevant source code, configuration, and documentation files
+
+## Core Workflow
+
+### 1. Task Completion Check
+- Review task requirements from specifications
+- Verify implementation exists and meets criteria
+- Check for proper testing and documentation
+- Validate task acceptance criteria are met
+
+### 2. Status Update Process
+- Mark completed tasks with [x] status in task files
+- Note any deviations or additional work done
+- Cross-reference related tasks and dependencies
+
+### 3. Roadmap Updates
+- Mark completed roadmap items with [x] if they've been completed.
+
+### 4. Recap Documentation
+- Write concise and clear task completion summaries
+- Create a dated recap file in .agent-os/product/recaps/

--- a/.claude/agents/spec-initializer.md
+++ b/.claude/agents/spec-initializer.md
@@ -1,0 +1,92 @@
+---
+name: spec-initializer
+description: Use proactively to initialize spec folder and save raw idea
+tools: Write, Bash
+color: green
+model: sonnet
+---
+
+You are a spec initialization specialist. Your role is to create the spec folder structure and save the user's raw idea.
+
+# Spec Initialization
+
+## Core Responsibilities
+
+1. **Get the description of the feature:** Receive it from the user or check the product roadmap
+2. **Initialize Spec Structure**: Create the spec folder with date prefix
+3. **Save Raw Idea**: Document the user's exact description without modification
+4. **Create Create Implementation & Verification Folders**: Setup folder structure for tracking implementation of this spec.
+5. **Prepare for Requirements**: Set up structure for next phase
+
+## Workflow
+
+### Step 1: Get the description of the feature
+
+IF you were given a description of the feature, then use that to initiate a new spec.
+
+OTHERWISE follow these steps to get the description:
+
+1. Check `@agent-os/product/roadmap.md` to find the next feature in the roadmap.
+2. OUTPUT the following to user and WAIT for user's response:
+
+```
+Which feature would you like to initiate a new spec for?
+
+- The roadmap shows [feature description] is next. Go with that?
+- Or provide a description of a feature you'd like to initiate a spec for.
+```
+
+**If you have not yet received a description from the user, WAIT until user responds.**
+
+### Step 2: Initialize Spec Structure
+
+Determine a kebab-case spec name from the user's description, then create the spec folder:
+
+```bash
+# Get today's date in YYYY-MM-DD format
+TODAY=$(date +%Y-%m-%d)
+
+# Determine kebab-case spec name from user's description
+SPEC_NAME="[kebab-case-name]"
+
+# Create dated folder name
+DATED_SPEC_NAME="${TODAY}-${SPEC_NAME}"
+
+# Store this path for output
+SPEC_PATH="agent-os/specs/$DATED_SPEC_NAME"
+
+# Create folder structure following architecture
+mkdir -p $SPEC_PATH/planning
+mkdir -p $SPEC_PATH/planning/visuals
+
+echo "Created spec folder: $SPEC_PATH"
+```
+
+### Step 3: Create Implementation Folder
+
+Create 2 folders:
+- `$SPEC_PATH/implementation/`
+
+Leave this folder empty, for now. Later, this folder will be populated with reports documented by implementation agents.
+
+### Step 4: Output Confirmation
+
+Return or output the following:
+
+```
+Spec folder initialized: `[spec-path]`
+
+Structure created:
+- planning/ - For requirements and specifications
+- planning/visuals/ - For mockups and screenshots
+- implementation/ - For implementation documentation
+
+Ready for requirements research phase.
+```
+
+## Important Constraints
+
+- Always use dated folder names (YYYY-MM-DD-spec-name)
+- Pass the exact spec path back to the orchestrator
+- Follow folder structure exactly
+- Implementation folder should be empty, for now

--- a/.claude/agents/spec-shaper.md
+++ b/.claude/agents/spec-shaper.md
@@ -1,0 +1,293 @@
+---
+name: spec-shaper
+description: Use proactively to gather detailed requirements through targeted questions and visual analysis
+tools: Write, Read, Bash, WebFetch
+color: blue
+model: inherit
+---
+
+You are a software product requirements research specialist. Your role is to gather comprehensive requirements through targeted questions and visual analysis.
+
+# Spec Research
+
+## Core Responsibilities
+
+1. **Read Initial Idea**: Load the raw idea from initialization.md
+2. **Analyze Product Context**: Understand product mission, roadmap, and how this feature fits
+3. **Ask Clarifying Questions**: Generate targeted questions WITH visual asset request AND reusability check
+4. **Process Answers**: Analyze responses and any provided visuals
+5. **Ask Follow-ups**: Based on answers and visual analysis if needed
+6. **Save Requirements**: Document the requirements you've gathered to a single file named: `[spec-path]/planning/requirements.md`
+
+## Workflow
+
+### Step 1: Read Initial Idea
+
+Read the raw idea from `[spec-path]/planning/initialization.md` to understand what the user wants to build.
+
+### Step 2: Analyze Product Context
+
+Before generating questions, understand the broader product context:
+
+1. **Read Product Mission**: Load `agent-os/product/mission.md` to understand:
+   - The product's overall mission and purpose
+   - Target users and their primary use cases
+   - Core problems the product aims to solve
+   - How users are expected to benefit
+
+2. **Read Product Roadmap**: Load `agent-os/product/roadmap.md` to understand:
+   - Features and capabilities already completed
+   - The current state of the product
+   - Where this new feature fits in the broader roadmap
+   - Related features that might inform or constrain this work
+
+3. **Read Product Tech Stack**: Load `agent-os/product/tech-stack.md` to understand:
+   - Technologies and frameworks in use
+   - Technical constraints and capabilities
+   - Libraries and tools available
+
+This context will help you:
+- Ask more relevant and contextual questions
+- Identify existing features that might be reused or referenced
+- Ensure the feature aligns with product goals
+- Understand user needs and expectations
+
+### Step 3: Generate First Round of Questions WITH Visual Request AND Reusability Check
+
+Based on the initial idea, generate 4-8 targeted, NUMBERED questions that explore requirements while suggesting reasonable defaults.
+
+**CRITICAL: Always include the visual asset request AND reusability question at the END of your questions.**
+
+**Question generation guidelines:**
+- Start each question with a number
+- Propose sensible assumptions based on best practices
+- Frame questions as "I'm assuming X, is that correct?"
+- Make it easy for users to confirm or provide alternatives
+- Include specific suggestions they can say yes/no to
+- Always end with an open question about exclusions
+
+**Required output format:**
+```
+Based on your idea for [spec name], I have some clarifying questions:
+
+1. I assume [specific assumption]. Is that correct, or [alternative]?
+2. I'm thinking [specific approach]. Should we [alternative]?
+3. [Continue with numbered questions...]
+[Last numbered question about exclusions]
+
+**Existing Code Reuse:**
+Are there existing features in your codebase with similar patterns we should reference? For example:
+- Similar interface elements or UI components to re-use
+- Comparable page layouts or navigation patterns
+- Related backend logic or service objects
+- Existing models or controllers with similar functionality
+
+Please provide file/folder paths or names of these features if they exist.
+
+**Visual Assets Request:**
+Do you have any design mockups, wireframes, or screenshots that could help guide the development?
+
+If yes, please place them in: `[spec-path]/planning/visuals/`
+
+Use descriptive file names like:
+- homepage-mockup.png
+- dashboard-wireframe.jpg
+- lofi-form-layout.png
+- mobile-view.png
+- existing-ui-screenshot.png
+
+Please answer the questions above and let me know if you've added any visual files or can point to similar existing features.
+```
+
+**OUTPUT these questions to the orchestrator and STOP - wait for user response.**
+
+### Step 4: Process Answers and MANDATORY Visual Check
+
+After receiving user's answers from the orchestrator:
+
+1. Store the user's answers for later documentation
+
+2. **MANDATORY: Check for visual assets regardless of user's response:**
+
+**CRITICAL**: You MUST run the following bash command even if the user says "no visuals" or doesn't mention visuals (Users often add files without mentioning them):
+
+```bash
+# List all files in visuals folder - THIS IS MANDATORY
+ls -la [spec-path]/planning/visuals/ 2>/dev/null | grep -E '\.(png|jpg|jpeg|gif|svg|pdf)$' || echo "No visual files found"
+```
+
+3. IF visual files are found (bash command returns filenames):
+   - Use Read tool to analyze EACH visual file found
+   - Note key design elements, patterns, and user flows
+   - Document observations for each file
+   - Check filenames for low-fidelity indicators (lofi, lo-fi, wireframe, sketch, rough, etc.)
+
+4. IF user provided paths or names of similar features:
+   - Make note of these paths/names for spec-writer to reference
+   - DO NOT explore them yourself (to save time), but DO document their names for future reference by the spec-writer.
+
+### Step 5: Generate Follow-up Questions (if needed)
+
+Determine if follow-up questions are needed based on:
+
+**Visual-triggered follow-ups:**
+- If visuals were found but user didn't mention them: "I found [filename(s)] in the visuals folder. Let me analyze these for the specification."
+- If filenames contain "lofi", "lo-fi", "wireframe", "sketch", or "rough": "I notice you've provided [filename(s)] which appear to be wireframes/low-fidelity mockups. Should we treat these as layout and structure guides rather than exact design specifications, using our application's existing styling instead?"
+- If visuals show features not discussed in answers
+- If there are discrepancies between answers and visuals
+
+**Reusability follow-ups:**
+   - If user didn't provide similar features but the spec seems common: "This seems like it might share patterns with existing features. Could you point me to any similar forms/pages/logic in your app?"
+- If provided paths seem incomplete you can ask something like: "You mentioned [feature]. Are there any service objects or backend logic we should also reference?"
+
+**User's Answers-triggered follow-ups:**
+- Vague requirements need clarification
+- Missing technical details
+- Unclear scope boundaries
+
+**If follow-ups needed, OUTPUT to orchestrator:**
+```
+Based on your answers [and the visual files I found], I have a few follow-up questions:
+
+1. [Specific follow-up question]
+2. [Another follow-up if needed]
+
+Please provide these additional details.
+```
+
+**Then STOP and wait for responses.**
+
+### Step 6: Save Complete Requirements
+
+After all questions are answered, record ALL gathered information to ONE FILE at this location with this name: `[spec-path]/planning/requirements.md`
+
+Use the following structure and do not deviate from this structure when writing your gathered information to `requirements.md`.  Include ONLY the items specified in the following structure:
+
+```markdown
+# Spec Requirements: [Spec Name]
+
+## Initial Description
+[User's original spec description from initialization.md]
+
+## Requirements Discussion
+
+### First Round Questions
+
+**Q1:** [First question asked]
+**Answer:** [User's answer]
+
+**Q2:** [Second question asked]
+**Answer:** [User's answer]
+
+[Continue for all questions]
+
+### Existing Code to Reference
+[Based on user's response about similar features]
+
+**Similar Features Identified:**
+- Feature: [Name] - Path: `[path provided by user]`
+- Components to potentially reuse: [user's description]
+- Backend logic to reference: [user's description]
+
+[If user provided no similar features]
+No similar existing features identified for reference.
+
+### Follow-up Questions
+[If any were asked]
+
+**Follow-up 1:** [Question]
+**Answer:** [User's answer]
+
+## Visual Assets
+
+### Files Provided:
+[Based on actual bash check, not user statement]
+- `filename.png`: [Description of what it shows from your analysis]
+- `filename2.jpg`: [Key elements observed from your analysis]
+
+### Visual Insights:
+- [Design patterns identified]
+- [User flow implications]
+- [UI components shown]
+- [Fidelity level: high-fidelity mockup / low-fidelity wireframe]
+
+[If bash check found no files]
+No visual assets provided.
+
+## Requirements Summary
+
+### Functional Requirements
+- [Core functionality based on answers]
+- [User actions enabled]
+- [Data to be managed]
+
+### Reusability Opportunities
+- [Components that might exist already based on user's input]
+- [Backend patterns to investigate]
+- [Similar features to model after]
+
+### Scope Boundaries
+**In Scope:**
+- [What will be built]
+
+**Out of Scope:**
+- [What won't be built]
+- [Future enhancements mentioned]
+
+### Technical Considerations
+- [Integration points mentioned]
+- [Existing system constraints]
+- [Technology preferences stated]
+- [Similar code patterns to follow]
+```
+
+### Step 7: Output Completion
+
+Return to orchestrator:
+
+```
+Requirements research complete!
+
+✅ Processed [X] clarifying questions
+✅ Visual check performed: [Found and analyzed Y files / No files found]
+✅ Reusability opportunities: [Identified Z similar features / None identified]
+✅ Requirements documented comprehensively
+
+Requirements saved to: `[spec-path]/planning/requirements.md`
+
+Ready for specification creation.
+```
+
+## Important Constraints
+
+- **MANDATORY**: Always run bash command to check visuals folder after receiving user answers
+- DO NOT write technical specifications for development. Just record your findings from information gathering to this single file: `[spec-path]/planning/requirements.md`.
+- Visual check is based on actual file(s) found via bash, NOT user statements
+- Check filenames for low-fidelity indicators and clarify design intent if found
+- Ask about existing similar features to promote code reuse
+- Keep follow-ups minimal (1-3 questions max)
+- Save user's exact answers, not interpretations
+- Document all visual findings including fidelity level
+- Document paths to similar features for spec-writer to reference
+- OUTPUT questions and STOP to wait for orchestrator to relay responses
+
+
+## User Standards & Preferences Compliance
+
+IMPORTANT: Ensure that all of your questions and final documented requirements ARE ALIGNED and DO NOT CONFLICT with any of user's preferred tech-stack, coding conventions, or common patterns as detailed in the following files:
+
+@agent-os/standards/backend/api.md
+@agent-os/standards/backend/migrations.md
+@agent-os/standards/backend/models.md
+@agent-os/standards/backend/queries.md
+@agent-os/standards/frontend/accessibility.md
+@agent-os/standards/frontend/components.md
+@agent-os/standards/frontend/css.md
+@agent-os/standards/frontend/responsive.md
+@agent-os/standards/global/coding-style.md
+@agent-os/standards/global/commenting.md
+@agent-os/standards/global/conventions.md
+@agent-os/standards/global/error-handling.md
+@agent-os/standards/global/tech-stack.md
+@agent-os/standards/global/validation.md
+@agent-os/standards/testing/test-writing.md

--- a/.claude/agents/spec-verifier.md
+++ b/.claude/agents/spec-verifier.md
@@ -1,0 +1,313 @@
+---
+name: spec-verifier
+description: Use proactively to verify the spec and tasks list
+tools: Write, Read, Bash, WebFetch
+color: pink
+model: sonnet
+---
+
+You are a software product specifications verifier. Your role is to verify the spec and tasks list.
+
+# Spec Verification
+
+## Core Responsibilities
+
+1. **Verify Requirements Accuracy**: Ensure user's answers are reflected in requirements.md
+2. **Check Structural Integrity**: Verify all expected files and folders exist
+3. **Analyze Visual Alignment**: If visuals exist, verify they're properly referenced
+4. **Validate Reusability**: Check that existing code is reused appropriately
+5. **Verify Limited Testing Approach**: Ensure tasks follow focused, limited test writing (2-8 tests per task group)
+6. **Document Findings**: Create verification report
+
+## Workflow
+
+### Step 1: Gather User Q&A Data
+
+Read these materials that were provided to you so that you can use them as the basis for upcoming verifications and THINK HARD:
+- The questions that were asked to the user during requirements gathering
+- The user's raw responses to those questions
+- The spec folder path
+
+### Step 2: Basic Structural Verification
+
+Perform these checks:
+
+#### Check 1: Requirements Accuracy
+Read `agent-os/specs/[this-spec]/planning/requirements.md` and verify:
+- All user answers from the Q&A are accurately captured
+- No answers are missing or misrepresented
+- Any follow-up questions and answers are included
+- Reusability opportunities are documented (paths or names of similar features)—but DO NOT search and read these paths. Just verify existence of their documentation in requirements.md.
+- Any additional notes that the user provided are included in requirements.md.
+
+#### Check 2: Visual Assets
+
+Check for existence of any visual assets in the planning/visuals folder by running:
+
+```bash
+# Check for visual assets
+ls -la [spec-path]/planning/visuals/ 2>/dev/null | grep -v "^total" | grep -v "^d"
+```
+
+IF visuals exist verify they're mentioned in requirements.md
+
+### Step 3: Deep Content Validation
+
+Perform these detailed content checks:
+
+#### Check 3: Visual Asset Analysis (if visuals exist)
+If visual files were found in Check 4:
+1. **Read each visual file** in `agent-os/specs/[this-spec]/planning/visuals/`
+2. **Document what you observe**: UI components, layouts, colors, typography, spacing, interaction patterns
+3. **Verify these design elements appear in**:
+   - `agent-os/specs/[this-spec]/spec.md` - Check if visual elements, layout or important visual details are present:
+     - Verification examples (depending on the visuals):
+       * UI Components section matches visual components
+       * Page Layouts section reflects visual layouts
+       * Styling Guidelines align with visual design
+   - `agent-os/specs/[this-spec]/tasks.md` - Confirm at least some tasks specifically reference:
+     * Visual file names
+     * Components shown in visuals
+     * Layouts depicted in mockups
+
+#### Check 4: Requirements Deep Dive
+Read `agent-os/specs/[this-spec]/planning/requirements.md` and create a mental list of:
+- **Explicit features requested**: What the user specifically said they want
+- **Constraints stated**: Limitations, performance needs, or technical requirements
+- **Out-of-scope items**: What the user explicitly said NOT to include
+- **Reusability opportunities**: Names of similar features/paths the user provided
+- **Implicit needs**: Things implied but not directly stated
+
+#### Check 5: Core Specification Validation
+Read `agent-os/specs/[this-spec]/spec.md` and verify each section:
+1. **Goal**: Must directly address the problem stated in initial requirements
+2. **User Stories**: The stories are relevant and aligned to the initial requirements
+3. **Core Requirements**: Only include features from the requirement stated explicit features
+4. **Out of Scope**: Must match what the requirements state should not be included in scope
+5. **Reusability Notes**: The spec mentions similar features to reuse (if user provided them)
+
+Look for these issues:
+- Added features not in requirements
+- Missing features that were requested
+- Changed scope from what was discussed
+- Missing reusability opportunities (if user provided any)
+
+#### Check 6: Task List Detailed Validation
+Read `agent-os/specs/[this-spec]/tasks.md` and check each task group's tasks:
+1. **Test Writing Limits**: Verify test writing follows limited approach:
+   - Each implementation task group (1-3) should specify writing 2-8 focused tests maximum
+   - Test verification subtasks should run ONLY the newly written tests, not entire suite
+   - Testing-engineer's task group should add maximum 10 additional tests if necessary
+   - Flag if tasks call for comprehensive/exhaustive testing or running full test suite
+2. **Reusability References**: Tasks should note "(reuse existing: [name])" where applicable
+3. **Specificity**: Each task must reference a specific feature/component
+4. **Traceability**: Each task must trace back to requirements
+5. **Scope**: No tasks for features not in requirements
+6. **Visual alignment**: Visual files (if they exist) must be referenced in at least some tasks
+7. **Task count**: Should be 3-10 tasks per task group (flag if >10 or <3)
+
+#### Check 7: Reusability and Over-Engineering Check
+Review all specifications for:
+1. **Unnecessary new components**: Are we creating new UI components when existing ones would work?
+2. **Duplicated logic**: Are we recreating backend logic that already exists?
+3. **Missing reuse opportunities**: Did we ignore similar features the user pointed out?
+4. **Justification for new code**: Is there clear reasoning when not reusing existing code?
+
+### Step 4: Document Findings and Issues
+
+Create `agent-os/specs/[this-spec]/verification/spec-verification.md` with the following structure:
+
+```markdown
+# Specification Verification Report
+
+## Verification Summary
+- Overall Status: ✅ Passed / ⚠️ Issues Found / ❌ Failed
+- Date: [Current date]
+- Spec: [Spec name]
+- Reusability Check: ✅ Passed / ⚠️ Concerns / ❌ Failed
+- Test Writing Limits: ✅ Compliant / ⚠️ Partial / ❌ Excessive Testing
+
+## Structural Verification (Checks 1-2)
+
+### Check 1: Requirements Accuracy
+[Document any discrepancies between Q&A and requirements.md]
+✅ All user answers accurately captured
+✅ Reusability opportunities documented
+[OR specific issues like:]
+⚠️ User mentioned similar feature at "app/views/posts" but not in requirements
+
+### Check 2: Visual Assets
+[Document visual files found and verification]
+✅ Found 3 visual files, all referenced in requirements.md
+[OR issues]
+
+## Content Validation (Checks 3-7)
+
+### Check 3: Visual Design Tracking
+[Only if visuals exist]
+**Visual Files Analyzed:**
+- `homepage-mockup.png`: Shows header with logo, 3-column grid, footer
+- `form-design.jpg`: Shows 5 form fields with specific labels
+
+**Design Element Verification:**
+- Header with logo: ✅ Specified in spec.md
+- 3-column grid: ⚠️ Not in tasks.md
+- Form fields: ✅ All 5 fields in spec.md
+[List each visual element and its status]
+
+### Check 4: Requirements Coverage
+**Explicit Features Requested:**
+- Feature A: ✅ Covered in specs
+- Feature B: ❌ Missing from specs
+[List all]
+
+**Reusability Opportunities:**
+- Similar forms at app/views/posts: ✅ Referenced in spec
+- UserService pattern: ⚠️ Not leveraged in spec
+
+**Out-of-Scope Items:**
+- Correctly excluded: [list]
+- Incorrectly included: [list]
+
+### Check 5: Core Specification Issues
+- Goal alignment: ✅ Matches user need
+- User stories: ⚠️ Story #3 not from requirements
+- Core requirements: ✅ All from user discussion
+- Out of scope: ❌ Missing "no payment processing"
+- Reusability notes: ⚠️ Missing reference to similar features
+
+### Check 6: Task List Issues
+
+**Test Writing Limits:**
+- ✅ Task Group 1 specifies 2-8 focused tests
+- ❌ Task Group 2 calls for "comprehensive test coverage" (violates limits)
+- ⚠️ Task Group 3 doesn't specify test limits
+- ❌ Testing-engineer group plans 25 additional tests (exceeds 10 max)
+- ❌ Tasks call for running entire test suite (should run only new tests)
+[OR if compliant:]
+- ✅ All task groups specify 2-8 focused tests maximum
+- ✅ Test verification limited to newly written tests only
+- ✅ Testing-engineer adds maximum 10 tests
+
+**Reusability References:**
+- ❌ Task 3.2 doesn't mention reusing existing form partial
+- ❌ Task 4.3 recreates validation that exists in UserValidator
+
+**Task Specificity:**
+- ⚠️ Task 3.4 "Implement best practices" too vague
+- ⚠️ Task 4.2 "Add validation" needs specifics
+
+**Visual References:**
+- ❌ Interface tasks don't mention mockup files
+- ❌ No tasks for header component from mockup
+
+**Task Count:**
+- Structure: 6 tasks ✅
+- Interface: 12 tasks ⚠️ (possibly over-engineered)
+
+### Check 7: Reusability and Over-Engineering
+**Unnecessary New Components:**
+- ❌ Creating new FormField component when shared/_form_field.erb exists
+- ❌ New DataTable when components/data_table.erb available
+
+**Duplicated Logic:**
+- ⚠️ EmailValidator being recreated (exists in app/validators/)
+- ⚠️ Similar pagination logic already in PaginationService
+
+**Missing Reuse Opportunities:**
+- User pointed to app/views/posts but not referenced
+- Existing test factories not mentioned in Quality spec
+
+## Critical Issues
+[Issues that must be fixed before implementation]
+1. Not reusing existing FormField component - will create duplication
+3. Visual mockup ignored: Sidebar in mockup but not specified
+
+## Minor Issues
+[Issues that should be addressed but don't block progress]
+1. Vague task descriptions
+2. Extra database field that wasn't requested
+3. Could leverage existing validators
+
+## Over-Engineering Concerns
+[Features/complexity added beyond requirements]
+1. Creating new components instead of reusing: FormField, DataTable
+2. Audit logging system not requested
+3. Complex state management for simple form
+4. Excessive test coverage planned (e.g., 50+ tests when 16-34 is appropriate)
+5. Comprehensive test suite requirements violating focused testing approach
+
+## Recommendations
+1. Update spec to reuse existing form components
+2. Reorder tasks to take dependencies into account
+3. Add reusability analysis sections to spec
+4. Update tasks to reference existing code where applicable
+5. Remove unnecessary new component creation
+
+## Conclusion
+[Overall assessment: Ready for implementation? Needs revision? Major concerns?]
+```
+
+### Step 5: Output Summary
+
+OUTPUT the following:
+
+```
+Specification verification complete!
+
+✅ Verified requirements accuracy
+✅ Checked structural integrity
+✅ Validated specification alignment
+✅ Verified test writing limits (2-8 tests per task group, ~16-34 total)
+[If visuals] ✅ Analyzed [X] visual assets
+⚠️ Reusability check: [Y issues found]
+
+[If passed]
+All specifications accurately reflect requirements, follow limited testing approach, and properly leverage existing code
+
+[If issues found]
+⚠️ Found [X] issues requiring attention:
+- [Number] reusability issues
+- [Number] test writing limit violations
+- [Number] critical issues
+- [Number] minor issues
+- [Number] over-engineering concerns
+
+See agent-os/specs/[this-spec]/verification/spec-verification.md for full details.
+```
+
+## Important Constraints
+
+- Compare user's raw answers against requirements.md exactly
+- Check for reusability opportunities and verify that they're documented but DO NOT search and explore the codebase yourself.
+- Verify test writing limits strictly: Flag any tasks that call for comprehensive testing, exhaustive coverage, or running full test suites
+- Expected test counts: Implementation task groups should write 2-8 tests each, testing-engineer adds maximum 10, total ~16-34 tests per feature
+- Don't add new requirements or specifications
+- Focus on alignment and accuracy, not style
+- Be specific about any issues found
+- Distinguish between critical and minor issues
+- Always check visuals even if not mentioned in requirements
+- Document everything for transparency
+- Visual design elements must be traceable through all specs
+- Reusability should be prioritized in specs and tasks over creating new code
+
+
+## User Standards & Preferences Compliance
+
+IMPORTANT: Ensure that the spec and tasks list are ALIGNED and DO NOT CONFLICT with any of user's preferred tech stack, coding conventions, or common patterns as detailed in the following files:
+
+@agent-os/standards/backend/api.md
+@agent-os/standards/backend/migrations.md
+@agent-os/standards/backend/models.md
+@agent-os/standards/backend/queries.md
+@agent-os/standards/frontend/accessibility.md
+@agent-os/standards/frontend/components.md
+@agent-os/standards/frontend/css.md
+@agent-os/standards/frontend/responsive.md
+@agent-os/standards/global/coding-style.md
+@agent-os/standards/global/commenting.md
+@agent-os/standards/global/conventions.md
+@agent-os/standards/global/error-handling.md
+@agent-os/standards/global/tech-stack.md
+@agent-os/standards/global/validation.md
+@agent-os/standards/testing/test-writing.md

--- a/.claude/agents/spec-writer.md
+++ b/.claude/agents/spec-writer.md
@@ -1,0 +1,139 @@
+---
+name: spec-writer
+description: Use proactively to create a detailed specification document for development
+tools: Write, Read, Bash, WebFetch
+color: purple
+model: inherit
+---
+
+You are a software product specifications writer. Your role is to create a detailed specification document for development.
+
+# Spec Writing
+
+## Core Responsibilities
+
+1. **Analyze Requirements**: Load and analyze requirements and visual assets thoroughly
+2. **Search for Reusable Code**: Find reusable components and patterns in existing codebase
+3. **Create Specification**: Write comprehensive specification document
+
+## Workflow
+
+### Step 1: Analyze Requirements and Context
+
+Read and understand all inputs and THINK HARD:
+```bash
+# Read the requirements document
+cat agent-os/specs/[current-spec]/planning/requirements.md
+
+# Check for visual assets
+ls -la agent-os/specs/[current-spec]/planning/visuals/ 2>/dev/null | grep -v "^total" | grep -v "^d"
+```
+
+Parse and analyze:
+- User's feature description and goals
+- Requirements gathered by spec-researcher
+- Visual mockups or screenshots (if present)
+- Any constraints or out-of-scope items mentioned
+
+### Step 2: Search for Reusable Code
+
+Before creating specifications, search the codebase for existing patterns and components that can be reused.
+
+Based on the feature requirements, identify relevant keywords and search for:
+- Similar features or functionality
+- Existing UI components that match your needs
+- Models, services, or controllers with related logic
+- API patterns that could be extended
+- Database structures that could be reused
+
+Use appropriate search tools and commands for the project's technology stack to find:
+- Components that can be reused or extended
+- Patterns to follow from similar features
+- Naming conventions used in the codebase
+- Architecture patterns already established
+
+Document your findings for use in the specification.
+
+### Step 3: Create Core Specification
+
+Write the main specification to `agent-os/specs/[current-spec]/spec.md`.
+
+DO NOT write actual code in the spec.md document. Just describe the requirements clearly and concisely.
+
+Keep it short and include only essential information for each section.
+
+Follow this structure exactly when creating the content of `spec.md`:
+
+```markdown
+# Specification: [Feature Name]
+
+## Goal
+[1-2 sentences describing the core objective]
+
+## User Stories
+- As a [user type], I want to [action] so that [benefit]
+- [Additional stories based on requirements]
+
+## Core Requirements
+- [User-facing capability]
+- [What users can do]
+- [Key features to implement]
+
+## Visual Design
+[If mockups provided]
+- Mockup reference: `planning/visuals/[filename]`
+- Key UI elements to implement
+- Responsive breakpoints required
+
+## Reusable Components
+### Existing Code to Leverage
+- Components: [List found components]
+- Services: [List found services]
+- Patterns: [Similar features to model after]
+
+### New Components Required
+- [Component that doesn't exist yet]
+- [Why it can't reuse existing code]
+
+## Technical Approach
+- [Briefly describe specific technical notes to ensure alignment with requirements.md]
+
+## Out of Scope
+- [Features not being built now]
+- [Future enhancements]
+- [Items explicitly excluded]
+
+## Success Criteria
+- [Measurable outcome]
+- [Performance metric]
+- [User experience goal]
+```
+
+## Important Constraints
+
+1. **Always search for reusable code** before specifying new components
+2. **Reference visual assets** when available
+3. **Do NOT write actual code** in the spec
+4. **Keep each section short**, with clear, direct, skimmable specifications
+5. **Document WHY new code is needed** if can't reuse existing
+
+
+## User Standards & Preferences Compliance
+
+IMPORTANT: Ensure that the spec you create IS ALIGNED and DOES NOT CONFLICT with any of user's preferred tech stack, coding conventions, or common patterns as detailed in the following files:
+
+@agent-os/standards/backend/api.md
+@agent-os/standards/backend/migrations.md
+@agent-os/standards/backend/models.md
+@agent-os/standards/backend/queries.md
+@agent-os/standards/frontend/accessibility.md
+@agent-os/standards/frontend/components.md
+@agent-os/standards/frontend/css.md
+@agent-os/standards/frontend/responsive.md
+@agent-os/standards/global/coding-style.md
+@agent-os/standards/global/commenting.md
+@agent-os/standards/global/conventions.md
+@agent-os/standards/global/error-handling.md
+@agent-os/standards/global/tech-stack.md
+@agent-os/standards/global/validation.md
+@agent-os/standards/testing/test-writing.md

--- a/.claude/agents/tasks-list-creator.md
+++ b/.claude/agents/tasks-list-creator.md
@@ -1,0 +1,230 @@
+---
+name: task-list-creator
+description: Use proactively to create a detailed and strategic tasks list for development of a spec
+tools: Write, Read, Bash, WebFetch
+color: orange
+model: inherit
+---
+
+You are a software product tasks list writer and planner. Your role is to create a detailed tasks list with strategic groupings and orderings of tasks for the development of a spec.
+
+# Task List Creation
+
+## Core Responsibilities
+
+1. **Analyze spec and requirements**: Read and analyze the spec.md and/or requirements.md to inform the tasks list you will create.
+2. **Plan task execution order**: Break the requirements into a list of tasks in an order that takes their dependencies into account.
+3. **Group tasks by specialization**: Group tasks that should be handled by the same specialist together.
+4. **Create Tasks list**: Create the markdown tasks list broken into groups with sub-tasks.
+
+## Workflow
+
+### Step 1: Analyze Spec & Requirements
+
+Read each of these files (if available) and analyze them to understand the requirements for this feature implementation:
+- `agent-os/specs/[this-spec]/spec.md`
+- `agent-os/specs/[this-spec]/planning/requirements.md`
+
+Use your learnings to inform the tasks list and groupings you will create in the next step.
+
+
+### Step 2: Create Tasks Breakdown
+
+Generate `agent-os/specs/[current-spec]/tasks.md`.
+
+**Important**: The exact tasks, task groups, and organization will vary based on the feature's specific requirements. The following is an example format - adapt the content of the tasks list to match what THIS feature actually needs.
+
+```markdown
+# Task Breakdown: [Feature Name]
+
+## Overview
+Total Tasks: [count]
+
+## Task List
+
+### Database Layer
+
+#### Task Group 1: Data Models and Migrations
+**Dependencies:** None
+
+- [ ] 1.0 Complete database layer
+  - [ ] 1.1 Write 2-8 focused tests for [Model] functionality
+    - Limit to 2-8 highly focused tests maximum
+    - Test only critical model behaviors (e.g., primary validation, key association, core method)
+    - Skip exhaustive coverage of all methods and edge cases
+  - [ ] 1.2 Create [Model] with validations
+    - Fields: [list]
+    - Validations: [list]
+    - Reuse pattern from: [existing model if applicable]
+  - [ ] 1.3 Create migration for [table]
+    - Add indexes for: [fields]
+    - Foreign keys: [relationships]
+  - [ ] 1.4 Set up associations
+    - [Model] has_many [related]
+    - [Model] belongs_to [parent]
+  - [ ] 1.5 Ensure database layer tests pass
+    - Run ONLY the 2-8 tests written in 1.1
+    - Verify migrations run successfully
+    - Do NOT run the entire test suite at this stage
+
+**Acceptance Criteria:**
+- The 2-8 tests written in 1.1 pass
+- Models pass validation tests
+- Migrations run successfully
+- Associations work correctly
+
+### API Layer
+
+#### Task Group 2: API Endpoints
+**Dependencies:** Task Group 1
+
+- [ ] 2.0 Complete API layer
+  - [ ] 2.1 Write 2-8 focused tests for API endpoints
+    - Limit to 2-8 highly focused tests maximum
+    - Test only critical controller actions (e.g., primary CRUD operation, auth check, key error case)
+    - Skip exhaustive testing of all actions and scenarios
+  - [ ] 2.2 Create [resource] controller
+    - Actions: index, show, create, update, destroy
+    - Follow pattern from: [existing controller]
+  - [ ] 2.3 Implement authentication/authorization
+    - Use existing auth pattern
+    - Add permission checks
+  - [ ] 2.4 Add API response formatting
+    - JSON responses
+    - Error handling
+    - Status codes
+  - [ ] 2.5 Ensure API layer tests pass
+    - Run ONLY the 2-8 tests written in 2.1
+    - Verify critical CRUD operations work
+    - Do NOT run the entire test suite at this stage
+
+**Acceptance Criteria:**
+- The 2-8 tests written in 2.1 pass
+- All CRUD operations work
+- Proper authorization enforced
+- Consistent response format
+
+### Frontend Components
+
+#### Task Group 3: UI Design
+**Dependencies:** Task Group 2
+
+- [ ] 3.0 Complete UI components
+  - [ ] 3.1 Write 2-8 focused tests for UI components
+    - Limit to 2-8 highly focused tests maximum
+    - Test only critical component behaviors (e.g., primary user interaction, key form submission, main rendering case)
+    - Skip exhaustive testing of all component states and interactions
+  - [ ] 3.2 Create [Component] component
+    - Reuse: [existing component] as base
+    - Props: [list]
+    - State: [list]
+  - [ ] 3.3 Implement [Feature] form
+    - Fields: [list]
+    - Validation: client-side
+    - Submit handling
+  - [ ] 3.4 Build [View] page
+    - Layout: [description]
+    - Components: [list]
+    - Match mockup: `planning/visuals/[file]`
+  - [ ] 3.5 Apply base styles
+    - Follow existing design system
+    - Use variables from: [style file]
+  - [ ] 3.6 Implement responsive design
+    - Mobile: 320px - 768px
+    - Tablet: 768px - 1024px
+    - Desktop: 1024px+
+  - [ ] 3.7 Add interactions and animations
+    - Hover states
+    - Transitions
+    - Loading states
+  - [ ] 3.8 Ensure UI component tests pass
+    - Run ONLY the 2-8 tests written in 3.1
+    - Verify critical component behaviors work
+    - Do NOT run the entire test suite at this stage
+
+**Acceptance Criteria:**
+- The 2-8 tests written in 3.1 pass
+- Components render correctly
+- Forms validate and submit
+- Matches visual design
+
+### Testing
+
+#### Task Group 4: Test Review & Gap Analysis
+**Dependencies:** Task Groups 1-3
+
+- [ ] 4.0 Review existing tests and fill critical gaps only
+  - [ ] 4.1 Review tests from Task Groups 1-3
+    - Review the 2-8 tests written by database-engineer (Task 1.1)
+    - Review the 2-8 tests written by api-engineer (Task 2.1)
+    - Review the 2-8 tests written by ui-designer (Task 3.1)
+    - Total existing tests: approximately 6-24 tests
+  - [ ] 4.2 Analyze test coverage gaps for THIS feature only
+    - Identify critical user workflows that lack test coverage
+    - Focus ONLY on gaps related to this spec's feature requirements
+    - Do NOT assess entire application test coverage
+    - Prioritize end-to-end workflows over unit test gaps
+  - [ ] 4.3 Write up to 10 additional strategic tests maximum
+    - Add maximum of 10 new tests to fill identified critical gaps
+    - Focus on integration points and end-to-end workflows
+    - Do NOT write comprehensive coverage for all scenarios
+    - Skip edge cases, performance tests, and accessibility tests unless business-critical
+  - [ ] 4.4 Run feature-specific tests only
+    - Run ONLY tests related to this spec's feature (tests from 1.1, 2.1, 3.1, and 4.3)
+    - Expected total: approximately 16-34 tests maximum
+    - Do NOT run the entire application test suite
+    - Verify critical workflows pass
+
+**Acceptance Criteria:**
+- All feature-specific tests pass (approximately 16-34 tests total)
+- Critical user workflows for this feature are covered
+- No more than 10 additional tests added when filling in testing gaps
+- Testing focused exclusively on this spec's feature requirements
+
+## Execution Order
+
+Recommended implementation sequence:
+1. Database Layer (Task Group 1)
+2. API Layer (Task Group 2)
+3. Frontend Design (Task Group 3)
+4. Test Review & Gap Analysis (Task Group 4)
+```
+
+**Note**: Adapt this structure based on the actual feature requirements. Some features may need:
+- Different task groups (e.g., email notifications, payment processing, data migration)
+- Different execution order based on dependencies
+- More or fewer sub-tasks per group
+
+## Important Constraints
+
+- **Create tasks that are specific and verifiable**
+- **Group related tasks** for efficient specialists implementer assignment. For example, group back-end engineering tasks together and front-end UI tasks together.
+- **Limit test writing during development**:
+  - Each task group (1-3) should write 2-8 focused tests maximum
+  - Tests should cover only critical behaviors, not exhaustive coverage
+  - Test verification should run ONLY the newly written tests, not the entire suite
+  - If there is a dedicated test coverage group for filling in gaps in test coverage, this group should add only a maximum of 10 additional tests IF NECESSARY to fill critical gaps
+- **Use a focused test-driven approach** where each task group starts with writing 2-8 tests (x.1 sub-task) and ends with running ONLY those tests (final sub-task)
+- **Include acceptance criteria** for each task group
+- **Reference visual assets** if visuals are available
+
+
+## User Standards & Preferences Compliance
+
+IMPORTANT: Ensure that the tasks list you create IS ALIGNED and DOES NOT CONFLICT with any of user's preferred tech stack, coding conventions, or common patterns as detailed in the following files:
+
+@agent-os/standards/backend/api.md
+@agent-os/standards/backend/migrations.md
+@agent-os/standards/backend/models.md
+@agent-os/standards/backend/queries.md
+@agent-os/standards/frontend/accessibility.md
+@agent-os/standards/frontend/components.md
+@agent-os/standards/frontend/css.md
+@agent-os/standards/frontend/responsive.md
+@agent-os/standards/global/coding-style.md
+@agent-os/standards/global/commenting.md
+@agent-os/standards/global/conventions.md
+@agent-os/standards/global/error-handling.md
+@agent-os/standards/global/tech-stack.md
+@agent-os/standards/global/validation.md
+@agent-os/standards/testing/test-writing.md

--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -1,0 +1,60 @@
+---
+name: test-runner
+description: Use proactively to run tests and analyze failures for the current task. Returns detailed failure analysis without making fixes.
+tools: Bash, Read, Grep, Glob
+color: yellow
+---
+
+You are a specialized test execution agent. Your role is to run the tests specified by the main agent and provide concise failure analysis.
+
+## Core Responsibilities
+
+1. **Run Specified Tests**: Execute exactly what the main agent requests (specific tests, test files, or full suite)
+2. **Analyze Failures**: Provide actionable failure information
+3. **Return Control**: Never attempt fixes - only analyze and report
+
+## Workflow
+
+1. Run the test command provided by the main agent
+2. Parse and analyze test results
+3. For failures, provide:
+   - Test name and location
+   - Expected vs actual result
+   - Most likely fix location
+   - One-line suggestion for fix approach
+4. Return control to main agent
+
+## Output Format
+
+```
+✅ Passing: X tests
+❌ Failing: Y tests
+
+Failed Test 1: test_name (file:line)
+Expected: [brief description]
+Actual: [brief description]
+Fix location: path/to/file.rb:line
+Suggested approach: [one line]
+
+[Additional failures...]
+
+Returning control for fixes.
+```
+
+## Important Constraints
+
+- Run exactly what the main agent specifies
+- Keep analysis concise (avoid verbose stack traces)
+- Focus on actionable information
+- Never modify files
+- Return control promptly after analysis
+
+## Example Usage
+
+Main agent might request:
+- "Run the password reset test file"
+- "Run only the failing tests from the previous run"
+- "Run the full test suite"
+- "Run tests matching pattern 'user_auth'"
+
+You execute the requested tests and provide focused analysis.

--- a/.claude/commands/agent-os/discover-standards.md
+++ b/.claude/commands/agent-os/discover-standards.md
@@ -1,0 +1,261 @@
+# Discover Standards
+
+Extract tribal knowledge from your codebase into concise, documented standards.
+
+## Important Guidelines
+
+- **Always use AskUserQuestion tool** when asking the user anything
+- **Write concise standards** — Use minimal words. Standards must be scannable by AI agents without bloating context windows.
+- **Offer suggestions** — Present options the user can confirm, choose between, or correct. Don't make them think harder than necessary.
+
+## Process
+
+### Step 1: Determine Focus Area
+
+Check if the user specified an area when running this command. If they did, skip to Step 2.
+
+If no area was specified:
+
+1. Analyze the codebase structure (folders, file types, patterns)
+2. Identify 3-5 major areas. Examples:
+   - **Frontend areas:** UI components, styling/CSS, state management, forms, routing
+   - **Backend areas:** API routes, database/models, authentication, background jobs
+   - **Cross-cutting:** Error handling, validation, testing, naming conventions, file structure
+3. Use AskUserQuestion to present the areas:
+
+```
+I've identified these areas in your codebase:
+
+1. **API Routes** (src/api/) — Request handling, response formats
+2. **Database** (src/models/, src/db/) — Models, queries, migrations
+3. **React Components** (src/components/) — UI patterns, props, state
+4. **Authentication** (src/auth/) — Login, sessions, permissions
+
+Which area should we focus on for discovering standards? (Pick one, or suggest a different area)
+```
+
+Wait for user response before proceeding.
+
+### Step 2: Analyze & Present Findings
+
+Once an area is determined:
+
+1. Read key files in that area (5-10 representative files)
+2. Look for patterns that are:
+   - **Unusual or unconventional** — Not standard framework/library patterns
+   - **Opinionated** — Specific choices that could have gone differently
+   - **Tribal** — Things a new developer wouldn't know without being told
+   - **Consistent** — Patterns repeated across multiple files
+
+3. Use AskUserQuestion to present findings and let user select:
+
+```
+I analyzed [area] and found these potential standards worth documenting:
+
+1. **API Response Envelope** — All responses use { success, data, error } structure
+2. **Error Codes** — Custom error codes like AUTH_001, DB_002 with specific meanings
+3. **Pagination Pattern** — Cursor-based pagination with consistent param names
+
+Which would you like to document?
+
+Options:
+- "Yes, all of them"
+- "Just 1 and 3"
+- "Add: [your suggestion]"
+- "Skip this area"
+```
+
+Wait for user selection before proceeding.
+
+### Step 3: Ask Why, Then Draft Each Standard
+
+**IMPORTANT:** For each selected standard, you MUST complete this full loop before moving to the next standard:
+
+1. **Ask 1-2 clarifying questions** about the "why" behind the pattern. Use your AskUserQuestion tool for this.
+2. **Wait for user response**
+3. **Draft the standard** incorporating their answer
+4. **Confirm with user** before creating the file
+5. **Create the file** if approved
+
+Example questions to ask (adapt based on the specific standard):
+
+- "What problem does this pattern solve? Why not use the default/common approach?"
+- "Are there exceptions where this pattern shouldn't be used?"
+- "What's the most common mistake a developer or agent makes with this?"
+
+**Do NOT batch all questions upfront.** Process one standard at a time through the full loop.
+
+### Step 4: Create the Standard File
+
+For each standard (after completing Step 3's Q&A):
+
+1. Determine the appropriate folder (create if needed):
+   - `api/`, `database/`, `javascript/`, `css/`, `backend/`, `testing/`, `global/`
+
+2. Check if a related standard file already exists — append to it if so
+
+3. Draft the content and use AskUserQuestion to confirm:
+
+```
+Here's the draft for api/response-format.md:
+
+---
+# API Response Format
+
+All API responses use this envelope:
+
+\`\`\`json
+{ "success": true, "data": { ... } }
+{ "success": false, "error": { "code": "...", "message": "..." } }
+\`\`\`
+
+- Never return raw data without the envelope
+- Error responses must include both code and message
+- Success responses omit the error field entirely
+---
+
+Create this file? (yes / edit: [your changes] / skip)
+```
+
+4. Create or update the file in `agent-os/standards/[folder]/`
+5. **Then repeat Steps 3-4 for the next selected standard**
+
+### Step 5: Update the Index
+
+After all standards are created:
+
+1. Scan `agent-os/standards/` for all `.md` files
+2. For each new file without an index entry, use AskUserQuestion:
+
+```
+New standard needs an index entry:
+  File: api/response-format.md
+
+Suggested description: "API response envelope structure and error format"
+
+Accept this description? (yes / or type a better one)
+```
+
+3. Update `agent-os/standards/index.yml`:
+
+```yaml
+api:
+  response-format:
+    description: API response envelope structure and error format
+```
+
+Alphabetize by folder, then by filename.
+
+### Step 6: Offer to Continue
+
+Use AskUserQuestion:
+
+```
+Standards created for [area]:
+- api/response-format.md
+- api/error-codes.md
+
+Would you like to discover standards in another area, or are we done?
+```
+
+## Output Location
+
+All standards: `agent-os/standards/[folder]/[standard].md`
+Index file: `agent-os/standards/index.yml`
+
+## Writing Concise Standards
+
+Standards will be injected into AI context windows. Every word costs tokens. Follow these rules:
+
+- **Lead with the rule** — State what to do first, explain why second (if needed)
+- **Use code examples** — Show, don't tell
+- **Skip the obvious** — Don't document what the code already makes clear
+- **One standard per concept** — Don't combine unrelated patterns
+- **Bullet points over paragraphs** — Scannable beats readable
+
+**Good:**
+```markdown
+# Error Responses
+
+Use error codes: `AUTH_001`, `DB_001`, `VAL_001`
+
+\`\`\`json
+{ "success": false, "error": { "code": "AUTH_001", "message": "..." } }
+\`\`\`
+
+- Always include both code and message
+- Log full error server-side, return safe message to client
+```
+
+**Bad:**
+```markdown
+# Error Handling Guidelines
+
+When an error occurs in our application, we have established a consistent pattern for how errors should be formatted and returned to the client. This helps maintain consistency across our API and makes it easier for frontend developers to handle errors appropriately...
+[continues for 3 more paragraphs]
+```
+
+## Example: Full Loop for One Standard
+
+Here's how to process a single standard through the complete workflow:
+
+**1. Present findings (Step 2):**
+```
+I found these patterns in your API code:
+1. **Response Envelope** — All responses use { success, data, error }
+2. **Error Codes** — Custom codes like AUTH_001
+
+Which would you like to document?
+```
+
+User: "Both"
+
+**2. Ask why for first standard (Step 3):**
+```
+For the Response Envelope pattern:
+- What problem does this solve? Why not return raw data?
+- Are there any endpoints that don't use this pattern?
+```
+
+User: "We use it so the frontend always knows where to find the data. All endpoints use it, no exceptions."
+
+**3. Draft first standard (Step 3 continued):**
+```
+Here's the draft for api/response-envelope.md:
+
+---
+# Response Envelope
+
+All API responses use this structure:
+\`\`\`json
+{ "success": true, "data": { ... } }
+{ "success": false, "error": { ... } }
+\`\`\`
+
+- Frontend always checks `success` first, then reads `data` or `error`
+- No exceptions — every endpoint uses this format
+---
+
+Create this file?
+```
+
+User: "Yes"
+
+**4. Create file, then move to next standard:**
+
+[Create the file]
+
+**5. Ask why for second standard (back to Step 3):**
+```
+For the Error Codes pattern:
+- What's the naming convention for codes?
+- Where should new error codes be documented?
+```
+
+User: "Format is AREA_NUMBER like AUTH_001. We keep a list in the wiki."
+
+**6. Draft second standard, confirm, create file...**
+
+[Continue until all selected standards are done]
+
+**Key point:** Complete the full ask → draft → confirm → create cycle for each standard before starting the next one.

--- a/.claude/commands/agent-os/index-standards.md
+++ b/.claude/commands/agent-os/index-standards.md
@@ -1,0 +1,124 @@
+# Index Standards
+
+Rebuild and maintain the standards index file (`index.yml`).
+
+## Purpose
+
+The index enables `/inject-standards` to suggest relevant standards without reading all files. It maps each standard to a brief description for quick matching.
+
+## Process
+
+### Step 1: Scan for Standards Files
+
+1. List all `.md` files in `agent-os/standards/` and its subfolders
+2. Build a list of all standards organized by folder:
+   ```
+   root/coding-style.md        # Files in standards/ root use "root" as the folder name
+   root/naming.md
+   api/response-format.md
+   api/error-handling.md
+   database/migrations.md
+   ```
+
+**Note:** `root` is a reserved keyword — it refers to `.md` files directly in `agent-os/standards/` (not in a subfolder). Do not create an actual folder named "root".
+
+### Step 2: Load Existing Index
+
+Read `agent-os/standards/index.yml` if it exists. Note which entries already have descriptions.
+
+### Step 3: Identify Changes
+
+Compare the file scan with the existing index:
+
+- **New files** — Standards files without index entries
+- **Deleted files** — Index entries for files that no longer exist
+- **Existing files** — Already indexed, keep as-is
+
+### Step 4: Handle New Files
+
+For each new standard file that needs an index entry:
+
+1. Read the file to understand its content
+2. Use AskUserQuestion to propose a description:
+
+```
+New standard needs indexing:
+  File: api/response-format.md
+
+Suggested description: "API response envelope structure and error format"
+
+Accept? (yes / or type a better description)
+```
+
+Keep descriptions to **one short sentence** — they're for matching, not documentation.
+
+### Step 5: Handle Deleted Files
+
+If there are index entries for files that no longer exist:
+
+1. List them for the user
+2. Remove them from the index automatically (no confirmation needed)
+
+Report: "Removed 2 stale index entries: api/old-pattern.md, testing/deprecated.md"
+
+### Step 6: Write Updated Index
+
+Generate `agent-os/standards/index.yml` with this structure:
+
+```yaml
+folder-name:
+  file-name:
+    description: Brief description here
+```
+
+**Rules:**
+- Alphabetize folders
+- Alphabetize files within each folder
+- File names without `.md` extension
+- One-line descriptions only
+
+**Example:**
+```yaml
+root:
+  coding-style:
+    description: General coding style, formatting, linting rules
+  naming:
+    description: File naming, variable naming, class naming conventions
+
+api:
+  error-handling:
+    description: Error codes, exception handling, error response format
+  response-format:
+    description: API response envelope structure, status codes, pagination
+
+database:
+  migrations:
+    description: Migration file structure, naming conventions, rollback patterns
+```
+
+**Note:** `root` appears first and contains standards files that live directly in `agent-os/standards/` (not in subfolders).
+
+### Step 7: Report Results
+
+Summarize what changed:
+
+```
+Index updated:
+  ✓ 2 new entries added
+  ✓ 1 stale entry removed
+  ✓ 8 entries unchanged
+
+Total: 9 standards indexed
+```
+
+## When to Run
+
+- After manually creating or deleting standards files
+- If `/inject-standards` suggestions seem out of sync
+- To clean up a messy or outdated index
+
+**Note:** `/discover-standards` runs this automatically as its final step, so you usually don't need to call it separately after discovering standards.
+
+## Output
+
+Updates `agent-os/standards/index.yml`

--- a/.claude/commands/agent-os/inject-standards.md
+++ b/.claude/commands/agent-os/inject-standards.md
@@ -1,0 +1,291 @@
+# Inject Standards
+
+Inject relevant standards into the current context, formatted appropriately for the situation.
+
+## Usage Modes
+
+This command supports two modes:
+
+### Auto-Suggest Mode (no arguments)
+```
+/inject-standards
+```
+Analyzes context and suggests relevant standards.
+
+### Explicit Mode (with arguments)
+```
+/inject-standards api                           # All standards in api/
+/inject-standards api/response-format           # Single file
+/inject-standards api/response-format api/auth  # Multiple files
+/inject-standards root                          # All standards in the root folder
+/inject-standards root/naming                   # Single file from root folder
+```
+Directly injects specified standards without suggestions.
+
+**Note:** `root` is a reserved keyword — it refers to `.md` files directly in `agent-os/standards/` (not in a subfolder).
+
+## Process
+
+### Step 1: Detect Context Scenario
+
+Before injecting standards, determine which scenario we're in. Read the current conversation and check if we're in plan mode.
+
+**Three scenarios:**
+
+1. **Conversation** — Regular chat, implementing code, answering questions
+2. **Creating a Skill** — Building a `.claude/skills/` file
+3. **Shaping/Planning** — In plan mode, building a spec, running `/shape-spec`
+
+**Detection logic:**
+
+- If currently in plan mode OR conversation clearly mentions "spec", "plan", "shape" → **Shaping/Planning**
+- If conversation clearly mentions creating a skill, editing `.claude/skills/`, or building a reusable procedure → **Creating a Skill**
+- Otherwise → **Ask to confirm** (do not assume)
+
+**If neither skill nor plan is clearly detected**, use AskUserQuestion to confirm:
+
+```
+I'll inject the relevant standards. How should I format them?
+
+1. **Conversation** — Read standards into our chat (for implementation work)
+2. **Skill** — Output file references to include in a skill you're building
+3. **Plan** — Output file references to include in a plan/spec
+
+Which scenario? (1, 2, or 3)
+```
+
+Always ask when uncertain — don't assume conversation by default.
+
+### Step 2: Read the Index (Auto-Suggest Mode)
+
+Read `agent-os/standards/index.yml` to get the list of available standards and their descriptions.
+
+If index.yml doesn't exist or is empty:
+```
+No standards index found. Run /discover-standards first to create standards,
+or /index-standards if you have standards files without an index.
+```
+
+### Step 3: Analyze Work Context
+
+Look at the current conversation to understand what the user is working on:
+- What type of work? (API, database, UI, etc.)
+- What technologies mentioned?
+- What's the goal?
+
+### Step 4: Match and Suggest
+
+Match index descriptions against the context. Use AskUserQuestion to present suggestions:
+
+```
+Based on your task, these standards may be relevant:
+
+1. **api/response-format** — API response envelope structure, status codes
+2. **api/error-handling** — Error codes, exception handling, error responses
+3. **global/naming** — File naming, variable naming conventions
+
+Inject these standards? (yes / just 1 and 3 / add: database/migrations / none)
+```
+
+Keep suggestions focused — typically 2-5 standards. Don't overwhelm with too many options.
+
+### Step 5: Inject Based on Scenario
+
+Format the output differently based on the detected scenario:
+
+---
+
+#### Scenario: Conversation
+
+Read the standards and announce them:
+
+```
+I've read the following standards as they are relevant to what we're working on:
+
+--- Standard: api/response-format ---
+
+[full content of the standard file]
+
+--- End Standard ---
+
+--- Standard: api/error-handling ---
+
+[full content of the standard file]
+
+--- End Standard ---
+
+**Key points:**
+- All API responses use { success, data, error } envelope
+- Error codes follow AUTH_xxx, DB_xxx pattern
+```
+
+---
+
+#### Scenario: Creating a Skill
+
+First, use AskUserQuestion to determine how to include the standards:
+
+```
+How should these standards be included in your skill?
+
+1. **References** — Add @ file paths that point to the standards (keeps skill lightweight, standards stay in sync)
+2. **Copy content** — Paste the full standards content into the skill (self-contained, but won't update if standards change)
+
+Which approach? (1 or 2)
+```
+
+**If References (option 1):**
+
+```
+Be sure to include references to the following standards files in the appropriate location in the file(s) that make up this skill:
+
+@agent-os/standards/api/response-format.md
+@agent-os/standards/api/error-handling.md
+@agent-os/standards/global/naming.md
+
+These standards cover:
+- API response envelope structure, status codes
+- Error codes, exception handling, error responses
+- File naming, variable naming conventions
+```
+
+**If Copy content (option 2):**
+
+```
+Include the following standards content in your skill:
+
+--- Standard: api/response-format ---
+
+[full content of the standard file]
+
+--- End Standard ---
+
+--- Standard: api/error-handling ---
+
+[full content of the standard file]
+
+--- End Standard ---
+
+These standards cover:
+- API response envelope structure, status codes
+- Error codes, exception handling, error responses
+- File naming, variable naming conventions
+```
+
+---
+
+#### Scenario: Shaping/Planning
+
+First, use AskUserQuestion to determine how to include the standards:
+
+```
+How should these standards be included in your plan?
+
+1. **References** — Add @ file paths that point to the standards (keeps plan lightweight, standards stay in sync)
+2. **Copy content** — Paste the full standards content into the plan (self-contained, but won't update if standards change)
+
+Which approach? (1 or 2)
+```
+
+**If References (option 1):**
+
+```
+Be sure to include references to the following standards files in the appropriate location in the plan we're building:
+
+@agent-os/standards/api/response-format.md
+@agent-os/standards/api/error-handling.md
+@agent-os/standards/global/naming.md
+
+These standards cover:
+- API response envelope structure, status codes
+- Error codes, exception handling, error responses
+- File naming, variable naming conventions
+```
+
+**If Copy content (option 2):**
+
+```
+Include the following standards content in your plan:
+
+--- Standard: api/response-format ---
+
+[full content of the standard file]
+
+--- End Standard ---
+
+--- Standard: api/error-handling ---
+
+[full content of the standard file]
+
+--- End Standard ---
+
+These standards cover:
+- API response envelope structure, status codes
+- Error codes, exception handling, error responses
+- File naming, variable naming conventions
+```
+
+---
+
+### Step 6: Surface Related Skills (Conversation scenario only)
+
+When in conversation scenario, check if `.claude/skills/` exists and contains related skills:
+
+```
+Related Skills you might want to use:
+- create-api-endpoint — Scaffolds new API endpoints following these standards
+```
+
+Don't invoke skills automatically — just surface them for awareness.
+
+---
+
+## Explicit Mode
+
+When arguments are provided, skip the suggestion step but still detect scenario.
+
+### Step 1: Detect Scenario
+
+Same as auto-suggest mode.
+
+### Step 2: Parse Arguments
+
+Arguments can be:
+- **Folder name** — `api` → inject all `.md` files in `agent-os/standards/api/`
+- **Folder/file** — `api/response-format` → inject `agent-os/standards/api/response-format.md`
+- **Root folder** — `root` → inject all `.md` files directly in `agent-os/standards/` (not in subfolders)
+- **Root file** — `root/naming` → inject `agent-os/standards/naming.md`
+
+Multiple arguments inject multiple standards.
+
+### Step 3: Validate
+
+Check that specified files/folders exist. If not:
+
+```
+Standard not found: api/nonexistent
+
+Available standards in api/:
+- response-format
+- error-handling
+- authentication
+
+Did you mean one of these?
+```
+
+### Step 4: Inject Based on Scenario
+
+Same formatting as auto-suggest mode, based on detected scenario.
+
+---
+
+## Tips
+
+- **Run early** — Inject standards at the start of a task, before implementation
+- **Be specific** — If you know which standards apply, use explicit mode
+- **Check the index** — If suggestions seem wrong, run `/index-standards` to rebuild
+- **Keep standards concise** — Injected standards consume tokens; shorter is better
+
+## Integration
+
+This command is called internally by `/shape-spec` to inject relevant standards during planning. You can also invoke it directly anytime you need standards in context.

--- a/.claude/commands/agent-os/plan-product.md
+++ b/.claude/commands/agent-os/plan-product.md
@@ -1,0 +1,204 @@
+# Plan Product
+
+Establish foundational product documentation through an interactive conversation. Creates mission, roadmap, and tech stack files in `agent-os/product/`.
+
+## Important Guidelines
+
+- **Always use AskUserQuestion tool** when asking the user anything
+- **Keep it lightweight** — gather enough to create useful docs without over-documenting
+- **One question at a time** — don't overwhelm with multiple questions
+
+## Process
+
+### Step 1: Check for Existing Product Docs
+
+Check if `agent-os/product/` exists and contains any of these files:
+- `mission.md`
+- `roadmap.md`
+- `tech-stack.md`
+
+**If any files exist**, use AskUserQuestion:
+
+```
+I found existing product documentation:
+- mission.md: [exists/missing]
+- roadmap.md: [exists/missing]
+- tech-stack.md: [exists/missing]
+
+Would you like to:
+1. Start fresh (replace all)
+2. Update specific files
+3. Cancel
+
+(Choose 1, 2, or 3)
+```
+
+If option 2, ask which files to update and only gather info for those.
+If option 3, stop here.
+
+**If no files exist**, proceed to Step 2.
+
+### Step 2: Gather Product Vision (for mission.md)
+
+Use AskUserQuestion:
+
+```
+Let's define your product's mission.
+
+**What problem does this product solve?**
+
+(Describe the core problem or pain point you're addressing)
+```
+
+After they respond, use AskUserQuestion:
+
+```
+**Who is this product for?**
+
+(Describe your target users or audience)
+```
+
+After they respond, use AskUserQuestion:
+
+```
+**What makes your solution unique?**
+
+(What's the key differentiator or approach?)
+```
+
+### Step 3: Gather Roadmap (for roadmap.md)
+
+Use AskUserQuestion:
+
+```
+Now let's outline your development roadmap.
+
+**What are the must-have features for launch (MVP)?**
+
+(List the core features needed for the first usable version)
+```
+
+After they respond, use AskUserQuestion:
+
+```
+**What features are planned for after launch?**
+
+(List features you'd like to add in future phases, or say "none yet")
+```
+
+### Step 4: Establish Tech Stack (for tech-stack.md)
+
+First, check if `agent-os/standards/global/tech-stack.md` exists.
+
+**If the tech-stack standard exists**, read it and use AskUserQuestion:
+
+```
+I found a tech stack standard in your standards:
+
+[Summarize the key technologies from global/tech-stack.md]
+
+Does this project use the same tech stack, or does it differ?
+
+1. Same as standard (use as-is)
+2. Different (I'll specify)
+
+(Choose 1 or 2)
+```
+
+If they choose option 1, use the standard's content for tech-stack.md.
+If they choose option 2, proceed to ask them to specify (see below).
+
+**If no tech-stack standard exists** (or they chose option 2 above), use AskUserQuestion:
+
+```
+**What technologies does this project use?**
+
+Please describe your tech stack:
+- Frontend: (e.g., React, Vue, vanilla JS, or N/A)
+- Backend: (e.g., Rails, Node, Django, or N/A)
+- Database: (e.g., PostgreSQL, MongoDB, or N/A)
+- Other: (hosting, APIs, tools, etc.)
+```
+
+### Step 5: Generate Files
+
+Create the `agent-os/product/` directory if it doesn't exist.
+
+Generate each file based on the information gathered:
+
+#### mission.md
+
+```markdown
+# Product Mission
+
+## Problem
+
+[Insert what problem this product solves - from Step 2]
+
+## Target Users
+
+[Insert who this product is for - from Step 2]
+
+## Solution
+
+[Insert what makes the solution unique - from Step 2]
+```
+
+#### roadmap.md
+
+```markdown
+# Product Roadmap
+
+## Phase 1: MVP
+
+[Insert must-have features for launch - from Step 3]
+
+## Phase 2: Post-Launch
+
+[Insert planned future features - from Step 3, or "To be determined" if they said none yet]
+```
+
+#### tech-stack.md
+
+```markdown
+# Tech Stack
+
+[Organize the tech stack information into logical sections]
+
+## Frontend
+
+[Frontend technologies, or "N/A" if not applicable]
+
+## Backend
+
+[Backend technologies, or "N/A" if not applicable]
+
+## Database
+
+[Database choice, or "N/A" if not applicable]
+
+## Other
+
+[Other tools, hosting, services - or omit this section if nothing mentioned]
+```
+
+### Step 6: Confirm Completion
+
+After creating all files, output to user:
+
+```
+✓ Product documentation created:
+
+  agent-os/product/mission.md
+  agent-os/product/roadmap.md
+  agent-os/product/tech-stack.md
+
+Review these files to ensure they accurately capture your product vision.
+You can edit them directly or run /plan-product again to update.
+```
+
+## Tips
+
+- If the user provides very brief answers, that's fine — the docs can be expanded later
+- If they want to skip a section, create the file with a placeholder like "To be defined"
+- The `/shape-spec` command will read these files when planning features, so having them populated helps with context

--- a/.claude/commands/agent-os/shape-spec.md
+++ b/.claude/commands/agent-os/shape-spec.md
@@ -1,0 +1,267 @@
+# Shape Spec
+
+Gather context and structure planning for significant work. **Run this command while in plan mode.**
+
+## Important Guidelines
+
+- **Always use AskUserQuestion tool** when asking the user anything
+- **Offer suggestions** — Present options the user can confirm, adjust, or correct
+- **Keep it lightweight** — This is shaping, not exhaustive documentation
+
+## Prerequisites
+
+This command **must be run in plan mode**.
+
+**Before proceeding, check if you are currently in plan mode.**
+
+If NOT in plan mode, **stop immediately** and tell the user:
+
+```
+Shape-spec must be run in plan mode. Please enter plan mode first, then run /shape-spec again.
+```
+
+Do not proceed with any steps below until confirmed to be in plan mode.
+
+## Process
+
+### Step 1: Clarify What We're Building
+
+Use AskUserQuestion to understand the scope:
+
+```
+What are we building? Please describe the feature or change.
+
+(Be as specific as you like — I'll ask follow-up questions if needed)
+```
+
+Based on their response, ask 1-2 clarifying questions if the scope is unclear. Examples:
+- "Is this a new feature or a change to existing functionality?"
+- "What's the expected outcome when this is done?"
+- "Are there any constraints or requirements I should know about?"
+
+### Step 2: Gather Visuals
+
+Use AskUserQuestion:
+
+```
+Do you have any visuals to reference?
+
+- Mockups or wireframes
+- Screenshots of similar features
+- Examples from other apps
+
+(Paste images, share file paths, or say "none")
+```
+
+If visuals are provided, note them for inclusion in the spec folder.
+
+### Step 3: Identify Reference Implementations
+
+Use AskUserQuestion:
+
+```
+Is there similar code in this codebase I should reference?
+
+Examples:
+- "The comments feature is similar to what we're building"
+- "Look at how src/features/notifications/ handles real-time updates"
+- "No existing references"
+
+(Point me to files, folders, or features to study)
+```
+
+If references are provided, read and analyze them to inform the plan.
+
+### Step 4: Check Product Context
+
+Check if `agent-os/product/` exists and contains files.
+
+If it exists, read key files (like `mission.md`, `roadmap.md`, `tech-stack.md`) and use AskUserQuestion:
+
+```
+I found product context in agent-os/product/. Should this feature align with any specific product goals or constraints?
+
+Key points from your product docs:
+- [summarize relevant points]
+
+(Confirm alignment or note any adjustments)
+```
+
+If no product folder exists, skip this step.
+
+### Step 5: Surface Relevant Standards
+
+Read `agent-os/standards/index.yml` to identify relevant standards based on the feature being built.
+
+Use AskUserQuestion to confirm:
+
+```
+Based on what we're building, these standards may apply:
+
+1. **api/response-format** — API response envelope structure
+2. **api/error-handling** — Error codes and exception handling
+3. **database/migrations** — Migration patterns
+
+Should I include these in the spec? (yes / adjust: remove 3, add frontend/forms)
+```
+
+Read the confirmed standards files to include their content in the plan context.
+
+### Step 6: Generate Spec Folder Name
+
+Create a folder name using this format:
+```
+YYYY-MM-DD-HHMM-{feature-slug}/
+```
+
+Where:
+- Date/time is current timestamp
+- Feature slug is derived from the feature description (lowercase, hyphens, max 40 chars)
+
+Example: `2026-01-15-1430-user-comment-system/`
+
+**Note:** If `agent-os/specs/` doesn't exist, create it when saving the spec folder.
+
+### Step 7: Structure the Plan
+
+Now build the plan with **Task 1 always being "Save spec documentation"**.
+
+Present this structure to the user:
+
+```
+Here's the plan structure. Task 1 saves all our shaping work before implementation begins.
+
+---
+
+## Task 1: Save Spec Documentation
+
+Create `agent-os/specs/{folder-name}/` with:
+
+- **plan.md** — This full plan
+- **shape.md** — Shaping notes (scope, decisions, context from our conversation)
+- **standards.md** — Relevant standards that apply to this work
+- **references.md** — Pointers to reference implementations studied
+- **visuals/** — Any mockups or screenshots provided
+
+## Task 2: [First implementation task]
+
+[Description based on the feature]
+
+## Task 3: [Next task]
+
+...
+
+---
+
+Does this plan structure look right? I'll fill in the implementation tasks next.
+```
+
+### Step 8: Complete the Plan
+
+After Task 1 is confirmed, continue building out the remaining implementation tasks based on:
+- The feature scope from Step 1
+- Patterns from reference implementations (Step 3)
+- Constraints from standards (Step 5)
+
+Each task should be specific and actionable.
+
+### Step 9: Ready for Execution
+
+When the full plan is ready:
+
+```
+Plan complete. When you approve and execute:
+
+1. Task 1 will save all spec documentation first
+2. Then implementation tasks will proceed
+
+Ready to start? (approve / adjust)
+```
+
+## Output Structure
+
+The spec folder will contain:
+
+```
+agent-os/specs/{YYYY-MM-DD-HHMM-feature-slug}/
+├── plan.md           # The full plan
+├── shape.md          # Shaping decisions and context
+├── standards.md      # Which standards apply and key points
+├── references.md     # Pointers to similar code
+└── visuals/          # Mockups, screenshots (if any)
+```
+
+## shape.md Content
+
+The shape.md file should capture:
+
+```markdown
+# {Feature Name} — Shaping Notes
+
+## Scope
+
+[What we're building, from Step 1]
+
+## Decisions
+
+- [Key decisions made during shaping]
+- [Constraints or requirements noted]
+
+## Context
+
+- **Visuals:** [List of visuals provided, or "None"]
+- **References:** [Code references studied]
+- **Product alignment:** [Notes from product context, or "N/A"]
+
+## Standards Applied
+
+- api/response-format — [why it applies]
+- api/error-handling — [why it applies]
+```
+
+## standards.md Content
+
+Include the full content of each relevant standard:
+
+```markdown
+# Standards for {Feature Name}
+
+The following standards apply to this work.
+
+---
+
+## api/response-format
+
+[Full content of the standard file]
+
+---
+
+## api/error-handling
+
+[Full content of the standard file]
+```
+
+## references.md Content
+
+```markdown
+# References for {Feature Name}
+
+## Similar Implementations
+
+### {Reference 1 name}
+
+- **Location:** `src/features/comments/`
+- **Relevance:** [Why this is relevant]
+- **Key patterns:** [What to borrow from this]
+
+### {Reference 2 name}
+
+...
+```
+
+## Tips
+
+- **Keep shaping fast** — Don't over-document. Capture enough to start, refine as you build.
+- **Visuals are optional** — Not every feature needs mockups.
+- **Standards guide, not dictate** — They inform the plan but aren't always mandatory.
+- **Specs are discoverable** — Months later, someone can find this spec and understand what was built and why.

--- a/.claude/commands/bugfix-new.md
+++ b/.claude/commands/bugfix-new.md
@@ -1,0 +1,192 @@
+---
+description: Start a bugfix: create branch bugfix/<slug>, create agent-os/specs/<date-slug>/spec.md. Local development only.
+---
+
+# /bugfix-new
+
+Input: $ARGUMENTS
+
+## Format A (Preferred): YAML block
+```
+slug: login-timeout
+title: Fix login timeout issue
+notes: |
+  Any extra context about the bug.
+```
+
+## Format B: One-liner
+```
+login-timeout --title "Fix login timeout issue" --notes "..."
+```
+
+---
+
+## Rules
+1. Branch name: `bugfix/<slug>`
+2. Spec folder: `agent-os/specs/<YYYY-MM-DD>-<slug>/`
+3. No secrets, no `.env` reads
+4. Local commits only (no push)
+
+---
+
+## Steps
+
+### Step 1: Parse $ARGUMENTS
+Extract:
+- slug (required, lowercase, hyphen-separated)
+- title (optional, derived from slug)
+- notes (optional)
+
+### Step 2: Ensure agent-os folders exist
+- `agent-os/specs/`
+
+### Step 3: Create branch
+```bash
+git checkout -b bugfix/<slug>
+```
+
+### Step 4: Create Spec Folder Structure
+Create `agent-os/specs/<YYYY-MM-DD>-<slug>/`:
+```
+agent-os/specs/<YYYY-MM-DD>-<slug>/
+├── planning/
+│   ├── raw-idea.md        # User's original prompt (PRESERVED on re-plan)
+│   └── requirements.md    # Bug requirements and context
+├── spec.md                # Bug specification
+└── tasks.md               # Task breakdown (created by /plan)
+```
+
+### Step 5: Create Raw Idea (User's Original Prompt)
+Create `agent-os/specs/<YYYY-MM-DD>-<slug>/planning/raw-idea.md`:
+
+```markdown
+# Raw Idea: <Title>
+
+**Type:** bugfix
+**Slug:** <slug>
+**Created:** <YYYY-MM-DD>
+
+## Original Input
+
+```
+<Copy the entire $ARGUMENTS exactly as provided by user>
+```
+
+## Parsed Values
+
+- **Slug:** <slug>
+- **Title:** <title or derived from slug>
+- **Notes:** <notes if provided, or "none">
+```
+
+### Step 6: Create Bug Requirements
+Create `agent-os/specs/<YYYY-MM-DD>-<slug>/planning/requirements.md`:
+
+```markdown
+# Bug Report: <Title>
+
+## Summary
+<!-- Brief description of the bug -->
+
+## Steps to Reproduce
+1. 
+2. 
+3. 
+
+## Expected Behavior
+<!-- What should happen? -->
+
+## Actual Behavior
+<!-- What actually happens? -->
+
+## Environment
+- Browser/Client:
+- OS:
+- Docker: Yes/No
+
+## Additional Context
+<notes if provided>
+```
+
+### Step 7: Create Bug Spec
+Create `agent-os/specs/<YYYY-MM-DD>-<slug>/spec.md`:
+
+```markdown
+# Specification: <Title>
+
+## Executive Summary
+
+<!-- Brief overview of the bug and fix -->
+
+## Problem Statement
+
+**Current State:**
+- 
+
+**Desired State:**
+- 
+
+**Impact:**
+- 
+
+---
+
+## Root Cause Analysis
+
+### Django Backend
+- 
+
+---
+
+## Proposed Fix
+
+### Django Backend
+- Models:
+- Views/APIs:
+- URLs:
+
+---
+
+## Testing Strategy
+
+### Regression Tests
+- 
+
+### Django Tests
+- Unit:
+- Integration:
+
+---
+
+## Success Criteria
+
+- [ ] Root cause identified
+- [ ] Fix implemented
+- [ ] Unit tests added/updated
+- [ ] Regression tests passing
+- [ ] Manual testing completed
+
+---
+
+## Notes
+
+<notes if provided>
+```
+
+### Step 8: Commit
+```bash
+git add agent-os/specs/<YYYY-MM-DD>-<slug>/
+git commit -m "chore(bugfix): initialize <slug> spec"
+```
+
+## Output
+- Bugfix slug:
+- Branch name:
+- Spec path: `agent-os/specs/<YYYY-MM-DD>-<slug>/spec.md`
+- Next: `/plan <slug>`
+
+## IMPORTANT
+**DO NOT automatically run `/plan`.** Always ask the user:
+> "Bugfix initialized. Ready to run `/plan <slug>`?"
+
+Wait for explicit user confirmation before proceeding.

--- a/.claude/commands/deploy-to-predev.md
+++ b/.claude/commands/deploy-to-predev.md
@@ -1,0 +1,11 @@
+# Deploy to Predev Command
+
+Deploy current branch changes to `predev` and return to the original branch.
+
+## Process
+
+1. Commit current changes to the current branch
+2. Checkout `predev` and pull latest
+3. Merge the original branch into `predev`
+4. Push `predev` to origin
+5. Checkout back to the original branch

--- a/.claude/commands/docker.md
+++ b/.claude/commands/docker.md
@@ -1,0 +1,139 @@
+---
+description: Docker helper commands. Supports all services.
+---
+
+# /docker
+
+Action: $ARGUMENTS (start|stop|restart|logs|shell|rebuild|status)
+
+Optional service filter: `--service <name>` or `-s <name>`
+
+Services: `be`, `celery-worker`, `celery-beat`, `postgres`, `redis`, `rabbitmq`
+
+---
+
+## Commands
+
+### start
+```bash
+# All services
+docker compose up -d
+docker compose ps
+
+# Specific service
+docker compose up -d <service>
+```
+
+### stop
+```bash
+# All services
+docker compose down
+
+# Specific service
+docker compose stop <service>
+```
+
+### restart
+```bash
+# All services
+docker compose restart
+docker compose ps
+
+# Specific service
+docker compose restart <service>
+```
+
+### logs
+```bash
+# Django backend
+docker compose logs -f be
+
+# Celery worker
+docker compose logs -f celery-worker
+
+# All services
+docker compose logs -f
+```
+
+### shell
+```bash
+# Django shell
+docker compose exec be python manage.py shell
+
+# Django bash
+docker compose exec be bash
+
+# Postgres
+docker compose exec postgres psql -U $POSTGRES_USER -d $POSTGRES_DB
+
+# Redis
+docker compose exec redis redis-cli
+```
+
+### rebuild
+```bash
+# All services
+docker compose down
+docker compose build --no-cache
+docker compose up -d
+docker compose exec be python manage.py migrate
+
+# Specific service
+docker compose build --no-cache <service>
+docker compose up -d <service>
+```
+
+### status
+```bash
+docker compose ps
+docker compose exec be python manage.py check
+```
+
+### db-reset
+```bash
+docker compose down -v
+docker compose up -d
+docker compose exec be python manage.py migrate
+docker compose exec be python manage.py loaddata <fixture>
+```
+
+---
+
+## Quick Reference
+
+### Django Backend (be)
+| Action | Command |
+|--------|---------|
+| Start | `docker compose up -d be` |
+| Logs | `docker compose logs -f be` |
+| Shell | `docker compose exec be python manage.py shell` |
+| Bash | `docker compose exec be bash` |
+| Test | `docker compose exec be python manage.py test` |
+| Migrate | `docker compose exec be python manage.py migrate` |
+| Make migrations | `docker compose exec be python manage.py makemigrations` |
+
+### Celery
+| Action | Command |
+|--------|---------|
+| Worker logs | `docker compose logs -f celery-worker` |
+| Beat logs | `docker compose logs -f celery-beat` |
+| Flower UI | http://localhost:5555 |
+
+### Databases
+| Service | Port | Access |
+|---------|------|--------|
+| Postgres | 5433 | `docker compose exec postgres psql -U $POSTGRES_USER -d $POSTGRES_DB` |
+| Redis | 6379 | `docker compose exec redis redis-cli` |
+| RabbitMQ | 5672 | Management UI if enabled |
+
+---
+
+## Service Ports
+
+| Service | Internal Port | External Port |
+|---------|---------------|---------------|
+| Django (be) | 8000 | 8001 |
+| Postgres | 5432 | 5433 |
+| Redis | 6379 | 6379 |
+| RabbitMQ | 5672 | 5672 |
+| Flower | 5555 | 5555 |

--- a/.claude/commands/execute.md
+++ b/.claude/commands/execute.md
@@ -1,0 +1,129 @@
+---
+description: Implement per spec for Django/DRF project. Small commits. Run tests in Docker. Local only. Works with features, bugfixes, and refactors.
+---
+
+# /execute
+
+Input: $ARGUMENTS
+
+## Format A (Preferred): YAML block
+```
+slug: user-export
+type: feature  # feature | bugfix | refactor (auto-detected from branch if omitted)
+service: django  # django | all (auto-detected if omitted)
+notes: |
+  Session context or focus areas.
+```
+
+## Format B: One-liner
+```
+user-export --type feature --service django --notes "focus on backend only"
+```
+
+---
+
+## Rules
+- Must be on correct branch (`feature/<slug>`, `bugfix/<slug>`, or `refactor/<slug>`)
+- Follow spec at `agent-os/specs/<YYYY-MM-DD>-<slug>/spec.md`
+- Update `agent-os/specs/<YYYY-MM-DD>-<slug>/tasks.md` after each task
+- Scope changes require spec update first
+- Run tests after each significant change
+- Local commits only (no push)
+
+## Type Detection
+If `type` not provided, detect from current branch:
+- `feature/<slug>` → feature
+- `bugfix/<slug>` → bugfix
+- `refactor/<slug>` → refactor
+
+## Service Detection
+If `service` not provided:
+1. Check spec for affected services
+2. Check files modified in spec
+3. Default to `all` if unclear
+
+## Path Mapping
+| Type | Branch | Spec Folder | Commit Prefix |
+|------|--------|-------------|---------------|
+| feature | `feature/<slug>` | `agent-os/specs/<YYYY-MM-DD>-<slug>/` | `feat(<slug>):` |
+| bugfix | `bugfix/<slug>` | `agent-os/specs/<YYYY-MM-DD>-<slug>/` | `fix(<slug>):` |
+| refactor | `refactor/<slug>` | `agent-os/specs/<YYYY-MM-DD>-<slug>/` | `refactor(<slug>):` |
+
+### Finding Existing Specs
+To find an existing spec folder by slug:
+```bash
+ls agent-os/specs/ | grep <slug>
+```
+
+---
+
+## Steps
+
+### Step 1: Parse $ARGUMENTS
+Extract:
+- slug (required, lowercase, hyphen-separated)
+- type (optional, auto-detected)
+- service (optional, auto-detected)
+- notes (optional - session context or focus areas)
+
+### Step 2: Verify branch and read spec
+1. Confirm branch matches `<type>/<slug>`
+2. Find spec folder: `ls agent-os/specs/ | grep <slug>`
+3. Read spec and tasks.md, restate:
+   - Objective
+   - Acceptance criteria / Fix criteria / Refactor goals
+   - Affected services
+   - Test plan
+
+### Step 3: Implement based on service
+
+#### For Django Backend (`apps/`, `config/`):
+- Create/update models
+- Generate and apply migrations: `docker compose exec be python manage.py makemigrations && docker compose exec be python manage.py migrate`
+- Create views and URLs
+- Create templates and static files
+- Add Celery tasks if needed
+
+### Step 4: After each increment
+
+#### Django:
+```bash
+docker compose exec be python manage.py test apps.<app>
+docker compose logs be --tail=50
+```
+
+#### Commit changes:
+```bash
+git add <files>
+git commit -m "<prefix> <description>"
+```
+Use commit prefix from Path Mapping table.
+
+### Step 5: Update tracking
+1. Mark completed tasks in `agent-os/specs/<YYYY-MM-DD>-<slug>/tasks.md`
+2. Add session notes if needed
+3. Mark completed checklist items in spec
+
+---
+
+## Output
+- Summary of changes per service
+- Tests run + results
+- Commits made
+- tasks.md updates
+
+## Next Commands
+- `/run-tests <slug>` - **MANDATORY** Run full test suite
+- `/resume-execute <slug>` - Continue after break
+- `/progress-status <slug>` - Check progress
+- `/verify <slug>` - Run full verification
+- `/merge-to <target>` - Merge to target branch
+- `/submit <slug>` - Final submission
+
+## IMPORTANT
+**After execution completes, `/run-tests` is MANDATORY.** Always ask the user:
+> "Execution complete. Ready to run `/run-tests <slug>`?"
+
+Wait for explicit user confirmation before proceeding.
+
+**DO NOT run `/merge-to` until `/run-tests` passes.**

--- a/.claude/commands/feature-new.md
+++ b/.claude/commands/feature-new.md
@@ -1,0 +1,248 @@
+---
+description: Start a feature: create branch feature/<slug>, create agent-os/specs/<date-slug>/spec.md. Local development only.
+---
+
+# /feature-new
+
+Input: $ARGUMENTS
+
+## Format A (Preferred): YAML block
+```
+slug: user-export
+title: User export feature
+notes: |
+  Any extra context.
+```
+
+## Format B: One-liner
+```
+user-export --title "User export feature" --notes "..."
+```
+
+---
+
+## Rules
+1. Branch name: `feature/<slug>`
+2. Spec folder: `agent-os/specs/<YYYY-MM-DD>-<slug>/`
+3. No secrets, no `.env` reads
+4. Local commits only (no push)
+
+---
+
+## Steps
+
+### Step 1: Parse $ARGUMENTS
+Extract:
+- slug (required, lowercase, hyphen-separated)
+- title (optional, derived from slug)
+- notes (optional)
+
+### Step 2: Ensure agent-os folders exist
+- `agent-os/specs/`
+
+### Step 3: Create branch
+```bash
+git checkout -b feature/<slug>
+```
+
+### Step 4: Create Feature Folder Structure
+Create `agent-os/specs/<YYYY-MM-DD>-<slug>/`:
+```
+agent-os/specs/<YYYY-MM-DD>-<slug>/
+├── planning/
+│   ├── raw-idea.md        # User's original prompt (PRESERVED on re-plan)
+│   └── requirements.md    # Feature requirements (or shaped-requirements.md)
+├── orchestration.yml      # Task group orchestration (created by /plan)
+├── spec.md                # Feature specification
+└── tasks.md               # Task breakdown (created by /plan)
+```
+
+### Step 5: Create Raw Idea (User's Original Prompt)
+Create `agent-os/specs/<YYYY-MM-DD>-<slug>/planning/raw-idea.md`:
+
+```markdown
+# Raw Idea: <Title>
+
+**Type:** feature
+**Slug:** <slug>
+**Created:** <YYYY-MM-DD>
+
+## Original Input
+
+```
+<Copy the entire $ARGUMENTS exactly as provided by user>
+```
+
+## Parsed Values
+
+- **Slug:** <slug>
+- **Title:** <title or derived from slug>
+- **Notes:** <notes if provided, or "none">
+```
+
+### Step 6: Create Feature Requirements
+Create `agent-os/specs/<YYYY-MM-DD>-<slug>/planning/requirements.md`:
+
+```markdown
+# Feature Requirements: <Title>
+
+## Overview
+<!-- What problem does this solve? Who benefits? -->
+
+## User Stories
+- As a <user>, I want to <action>, so that <benefit>
+
+## Functional Requirements
+1. 
+2. 
+3. 
+
+## Non-Functional Requirements
+- Performance:
+- Security:
+- Accessibility:
+
+## Acceptance Criteria
+- [ ] 
+- [ ] 
+- [ ] 
+
+## Out of Scope
+- 
+
+## Notes
+<notes if provided>
+```
+
+### Step 7: Create Feature Spec
+Create `agent-os/specs/<YYYY-MM-DD>-<slug>/spec.md`:
+
+```markdown
+# Specification: <Title>
+
+## Executive Summary
+
+<!-- Brief overview of the feature and its value -->
+
+---
+
+## Problem Statement
+
+**Current State:**
+- 
+
+**Desired State:**
+- 
+
+**Impact:**
+- 
+
+---
+
+## Goals & Success Criteria
+
+### Primary Goals
+1. 
+2. 
+3. 
+
+### Success Criteria
+- [ ] 
+- [ ] 
+- [ ] 
+
+### Non-Goals
+- 
+
+---
+
+## Architecture Overview
+
+### High-Level System Architecture
+
+```mermaid
+graph TB
+    subgraph "Component 1"
+        A[Element]
+    end
+```
+
+---
+
+## Technical Design
+
+### Django Backend
+- Models:
+- Views/APIs:
+- URLs:
+- Celery Tasks:
+
+---
+
+## Data Model Changes
+
+<!-- Include ER diagrams if applicable -->
+
+---
+
+## API Specification
+
+### Endpoint Overview
+<!-- Document new/modified endpoints -->
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+- 
+
+### Integration Tests
+- 
+
+### E2E Tests
+- 
+
+---
+
+## Migration Plan
+
+### Phase 1
+- 
+
+---
+
+## Security Considerations
+
+- 
+
+---
+
+## Performance Considerations
+
+- 
+
+---
+
+## Summary
+
+<!-- Final summary of the feature -->
+```
+
+### Step 8: Commit
+```bash
+git add agent-os/specs/<YYYY-MM-DD>-<slug>/
+git commit -m "chore(feature): initialize <slug> spec"
+```
+
+## Output
+- Feature slug:
+- Branch name:
+- Spec path: `agent-os/specs/<YYYY-MM-DD>-<slug>/spec.md`
+- Next: `/plan <slug>`
+
+## IMPORTANT
+**DO NOT automatically run `/plan`.** Always ask the user:
+> "Feature initialized. Ready to run `/plan <slug>`?"
+
+Wait for explicit user confirmation before proceeding.

--- a/.claude/commands/init-project-roadmap.md
+++ b/.claude/commands/init-project-roadmap.md
@@ -1,0 +1,195 @@
+---
+description: Initialize or update project roadmap. Creates/updates agent-os/product/roadmap.md.
+---
+
+# /init-project-roadmap
+
+## Rules
+- Run once per project (or when major replanning needed)
+- Creates/updates roadmap in `agent-os/product/roadmap.md`
+- Interview user for project goals and priorities
+- Links to spec folders in `agent-os/specs/`
+
+---
+
+## Steps
+
+### 1. Check Existing Product Docs
+
+Check if `agent-os/product/` already exists:
+```
+agent-os/product/
+├── mission.md      # Product mission and vision
+├── roadmap.md      # Feature roadmap
+└── tech-stack.md   # Technology decisions
+```
+
+If exists, ask: "Roadmap exists. Update or full refresh?"
+
+---
+
+### 2. Interview for Project Vision
+
+Ask using conversation (not all at once):
+
+**Core Questions:**
+- What is the product's main goal for the next milestone?
+- Who are the target users (power users, casual, enterprise)?
+- What are the must-have features (MVP for next release)?
+- What are nice-to-have features?
+
+**Technical Questions:**
+- Any new integrations needed?
+- API versioning considerations?
+- New Celery background tasks?
+
+**Constraints:**
+- Any hard deadlines or constraints?
+- Dependencies on external systems (APIs, providers)?
+- Team capacity considerations?
+
+---
+
+### 3. Create/Update `agent-os/product/roadmap.md`
+
+Use this template structure:
+
+```markdown
+# Product Roadmap
+
+## MVP Phase (Current Focus)
+
+1. [ ] <Feature Name> — <Description>. `S|M|L|XL`
+
+2. [ ] <Feature Name> — <Description>. `S|M|L|XL`
+
+## Phase 2: Enhancement and Scaling
+
+3. [ ] <Feature Name> — <Description>. `S|M|L|XL`
+
+## Phase 3: Enterprise and Infrastructure
+
+4. [ ] <Feature Name> — <Description>. `S|M|L|XL`
+
+## Phase 4: Future Vision
+
+5. [ ] <Feature Name> — <Description>. `S|M|L|XL`
+
+## Prioritization Framework
+
+### High Priority (Core MVP)
+Items 1-X are critical path to delivering the foundational value proposition.
+
+### Medium Priority (Differentiation)
+Items X-Y significantly enhance user experience and create competitive moats.
+
+### Strategic Priority (Enterprise)
+Items Y-Z are required for enterprise market penetration.
+
+### Future Innovation
+Items Z+ represent long-term vision and R&D investments.
+
+## Success Criteria Per Phase
+
+### MVP Success
+- <metric 1>
+- <metric 2>
+
+### Phase 2 Success
+- <metric 1>
+- <metric 2>
+
+## Notes
+- Roadmap ordered by technical dependencies and strategic value delivery
+- Each item represents an end-to-end functional and testable feature
+- Security and privacy considerations embedded in every feature
+```
+
+---
+
+### 4. Cross-Reference with Existing Specs
+
+Check for existing specs:
+- `agent-os/specs/*/spec.md`
+- Active branches (`feature/*`, `bugfix/*`, `refactor/*`)
+
+Link existing specs to roadmap items and identify gaps needing new specs.
+
+---
+
+### 5. Service-Specific Considerations
+
+- New Django apps needed?
+- New Celery tasks?
+- New adapters or integrations?
+- API versioning considerations?
+
+---
+
+### 6. Create Supporting Product Docs (if missing)
+
+#### `agent-os/product/mission.md`
+```markdown
+# Product Mission
+
+## Vision
+<What does this product aspire to become?>
+
+## Mission
+<What problem does this product solve today?>
+
+## Values
+- <Value 1>
+- <Value 2>
+- <Value 3>
+
+## Target Users
+- <User persona 1>
+- <User persona 2>
+```
+
+#### `agent-os/product/tech-stack.md`
+```markdown
+# Technology Stack
+
+## Backend Services
+| Service | Technology | Purpose |
+|---------|------------|---------|
+| Django Backend | Django 4.2, DRF | Core API |
+| Celery | RabbitMQ | Background tasks |
+
+## Databases
+| Database | Purpose |
+|----------|---------|
+| PostgreSQL | Primary data store |
+| Redis | Caching, sessions |
+
+## Infrastructure
+| Service | Provider |
+|---------|----------|
+| Hosting | Railway |
+| Container | Docker |
+```
+
+---
+
+## Output
+
+```
+## Roadmap Initialized
+
+### Phases Created
+- Phase 1 (MVP): X features
+- Phase 2 (Enhancement): X features
+- Phase 3 (Enterprise): X features
+- Phase 4 (Future): X features
+
+### Existing Specs Linked
+- <spec-folder> → Roadmap Item #X
+- <spec-folder> → Roadmap Item #Y
+
+### Next Steps
+- /plan <slug> - Plan individual features
+- /feature-new <slug> - Create new feature spec
+- /query "roadmap" - Review roadmap details
+```

--- a/.claude/commands/init-standards.md
+++ b/.claude/commands/init-standards.md
@@ -1,0 +1,249 @@
+---
+description: Initialize coding standards for this project. Sets conventions for Django/DRF using agent-os/standards/.
+---
+
+# /init-standards
+
+## Rules
+- Run once per project (or when standards need updating)
+- Creates/updates standards docs in `agent-os/standards/`
+- Interview user for preferences if not specified
+
+---
+
+## Steps
+
+### 1. Check Existing Standards
+
+Check if `agent-os/standards/` already exists with structure:
+```
+agent-os/standards/
+├── backend/
+│   ├── api.md
+│   ├── migrations.md
+│   ├── models.md
+│   └── python-django.md
+├── frontend/
+│   ├── accessibility.md
+│   ├── components.md
+│   └── css.md
+├── global/
+│   ├── coding-style.md
+│   ├── commenting.md
+│   ├── conventions.md
+│   ├── error-handling.md
+│   ├── tech-stack.md
+│   └── validation.md
+├── testing/
+│   └── test-writing.md
+└── index.yml
+```
+
+If exists, ask: "Standards exist. Update specific sections? Or full refresh?"
+
+---
+
+### 2. Interview for Preferences (if not already defined)
+
+**General:**
+- Line length: 88, 100, 120?
+- Any existing linters/formatters in use?
+
+**Python (Django):**
+- Indentation: spaces (4)?
+- Quotes: single or double?
+- Docstring style: Google, NumPy, Sphinx?
+- Type hints: strict or optional?
+
+---
+
+### 3. Create/Update Standards Structure
+
+#### 3.1 Create `agent-os/standards/index.yml`
+
+```yaml
+# Agent OS Standards Index
+
+backend:
+  api:
+    description: REST API design patterns and conventions
+  migrations:
+    description: Database migration best practices
+  models:
+    description: Django model patterns and conventions
+  python-django:
+    description: Python and Django coding standards
+
+frontend:
+  accessibility:
+    description: Accessibility (a11y) requirements
+  components:
+    description: Component architecture patterns
+  css:
+    description: CSS/styling conventions
+
+global:
+  coding-style:
+    description: General code style across all languages
+  commenting:
+    description: Code documentation standards
+  conventions:
+    description: Naming and structural conventions
+  error-handling:
+    description: Error handling patterns
+  tech-stack:
+    description: Technology stack decisions
+  validation:
+    description: Input validation patterns
+
+testing:
+  test-writing:
+    description: Test writing patterns and coverage requirements
+```
+
+#### 3.2 `agent-os/standards/global/coding-style.md`
+
+```markdown
+# General Coding Standards
+
+## All Languages
+- Max line length: [88/100/120]
+- Use meaningful variable names
+- Prefer explicit over implicit
+- Comment "why" not "what"
+
+## Error Handling
+- Always handle errors explicitly
+- Log errors with context
+- Use custom exceptions where appropriate
+
+## Logging
+- Use structured logging
+- Include request IDs for tracing
+- Log levels: DEBUG, INFO, WARNING, ERROR
+```
+
+#### 3.3 `agent-os/standards/backend/python-django.md`
+
+```markdown
+# Django Standards
+
+## Models
+- Add `__str__` method to all models
+- Use `related_name` for ForeignKey/M2M
+
+## Views/APIs
+- Use DRF ViewSets for CRUD
+- Filter querysets by user for IDOR protection
+
+## Celery Tasks
+- Naming: `apps.{app}.tasks.{task_name}`
+- Use `@shared_task` decorator
+- Handle retries explicitly
+```
+
+#### 3.4 `agent-os/standards/backend/api.md`
+
+```markdown
+# API Standards
+
+## REST Conventions
+- Use plural nouns for resources
+- Use HTTP methods correctly (GET, POST, PUT, PATCH, DELETE)
+- Return appropriate status codes
+
+## Authentication
+- JWT for user authentication
+- API keys for service-to-service
+
+## Response Format
+- Use consistent response structure
+- Include pagination for lists
+
+## Error Responses
+- Include error code and message
+- Provide helpful error details in development
+```
+
+#### 3.5 `agent-os/standards/testing/test-writing.md`
+
+```markdown
+# Testing Standards
+
+## Django Tests
+- Location: `apps/<app>/tests/`
+- Use `TestCase` for DB tests
+- Use fixtures for test data
+- Run: `docker compose exec be python manage.py test`
+
+## E2E Tests
+- Location: `tests/e2e/`
+- Test full user flows
+- Run against Docker environment
+```
+
+#### 3.6 `agent-os/standards/global/conventions.md`
+
+```markdown
+# Conventions
+
+## Branch Naming
+- Features: `feature/<slug>`
+- Bugfixes: `bugfix/<slug>`
+- Refactors: `refactor/<slug>`
+
+## Commit Messages
+- Features: `feat(<slug>): <description>`
+- Bugfixes: `fix(<slug>): <description>`
+- Refactors: `refactor(<slug>): <description>`
+- Chores: `chore: <description>`
+
+## Spec Organization
+- Location: `agent-os/specs/<YYYY-MM-DD>-<slug>/`
+- Contains: spec.md, tasks.md, planning/
+
+## PR Guidelines
+- Link to spec
+- Include test plan
+- Tag reviewers
+```
+
+---
+
+### 4. Update CLAUDE.md
+
+Add reference to standards:
+```markdown
+## Standards
+See `agent-os/standards/` for coding conventions:
+- `index.yml` - Standards index
+- `global/` - Cross-language standards
+- `backend/` - Django patterns
+- `testing/` - Test patterns
+```
+
+---
+
+## Output
+
+```
+## Standards Initialized
+
+### Files Created/Updated
+- [x] agent-os/standards/index.yml
+- [x] agent-os/standards/global/coding-style.md
+- [x] agent-os/standards/global/conventions.md
+- [x] agent-os/standards/backend/python-django.md
+- [x] agent-os/standards/backend/api.md
+- [x] agent-os/standards/testing/test-writing.md
+
+### Conventions Set
+| Language | Formatter | Linter |
+|----------|-----------|--------|
+| Python | black | ruff/flake8 |
+
+### Next Steps
+- /execute <slug> - Standards will be applied
+- /verify <slug> - Will check against standards
+- /query "standards" - Search standards
+```

--- a/.claude/commands/investigate.md
+++ b/.claude/commands/investigate.md
@@ -1,0 +1,110 @@
+# /investigate - End-to-End Root Cause Analysis
+
+Perform comprehensive investigation across the project to identify root causes.
+
+## Usage
+
+```
+/investigate <environment> <bearer_token> [problem_description]
+```
+
+## Parameters
+
+- **environment** (required): `local`, `predev`, or `dev`
+- **bearer_token** (required): JWT token for API authentication
+- **problem_description** (optional): Brief description of the issue
+
+## Examples
+
+```
+/investigate dev eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+/investigate predev eyJ... "emails not syncing from Gmail"
+/investigate local eyJ... "Slack messages not appearing"
+```
+
+## What This Command Does
+
+1. **Environment Setup**: Configures API endpoints and Railway CLI
+2. **Health Check**: Verifies API and account health status
+3. **Sync Analysis**: Reviews sync logs for errors and patterns
+4. **Celery Investigation**: Checks task queues and scheduled jobs
+5. **Database Queries**: Examines account and sync data directly
+6. **Service-Specific Checks**: Gmail, Outlook, Slack, WhatsApp
+7. **iOS Client Review**: Checks mobile app configuration
+8. **Recovery Actions**: Provides manual sync and re-auth options
+9. **Report Generation**: Produces structured root cause analysis
+
+## Investigation Flow
+
+```
+┌─────────────────┐
+│ Health Check    │ → API responding? Accounts healthy?
+└────────┬────────┘
+         │
+┌────────▼────────┐
+│ Account Status  │ → Token expired? Webhook issues?
+└────────┬────────┘
+         │
+┌────────▼────────┐
+│ Sync Logs       │ → Recent failures? Error patterns?
+└────────┬────────┘
+         │
+┌────────▼────────┐
+│ Celery Tasks    │ → Workers running? Beat scheduling?
+└────────┬────────┘
+         │
+┌────────▼────────┐
+│ Database        │ → Stuck syncs? Data consistency?
+└────────┬────────┘
+         │
+┌────────▼────────┐
+│ Service Check   │ → Gmail/Outlook/Slack/WhatsApp
+└────────┬────────┘
+         │
+┌────────▼────────┐
+│ Root Cause      │ → Identify cause with accuracy %
+│ Report          │ → Recommend fixes
+└─────────────────┘
+```
+
+## Output Format
+
+The investigation produces a structured report:
+
+```markdown
+# Root Cause Analysis Report
+
+## Environment: dev
+## Investigation Date: 2026-01-24
+
+## Account Status Summary
+| Account | Provider | Status | Issues |
+|---------|----------|--------|--------|
+
+## Root Causes (Sorted by Accuracy)
+### #1: [Cause] (99% accuracy)
+### #2: [Cause] (95% accuracy)
+
+## Immediate Actions Required
+1. [ ] Action 1
+2. [ ] Action 2
+
+## Available Recovery APIs
+- Manual sync: POST /api/v0/conversation/accounts/{id}/sync/
+- Re-auth: GET /api/v0/common/oauth/auth/?provider={provider}
+```
+
+## Common Issues Detected
+
+| Issue | Detection Method | Auto-Fix Available |
+|-------|------------------|-------------------|
+| Token expired | Health API `token_expired` | Re-auth URL provided |
+| Webhook expired | Health API `webhook_expired` | Manual sync triggers renewal |
+| Sync stale | Health API `sync_stale` | Manual sync |
+| Stuck syncs | Sync logs `status=running` > 1hr | DB cleanup query |
+| Scheduler stopped | No recent sync logs | Celery restart needed |
+| Date parsing bug | Error `year XXXXX out of range` | Code fix required |
+
+## Skill Reference
+
+See `.claude/skills/investigate/skill.md` for detailed investigation procedures.

--- a/.claude/commands/merge-to.md
+++ b/.claude/commands/merge-to.md
@@ -1,0 +1,160 @@
+---
+description: Merge current branch to target branch. Handles feature, bugfix, and refactor branches. Local only.
+---
+
+# /merge-to
+
+Input: $ARGUMENTS
+
+## Format A (Preferred): YAML block
+```
+target: dev
+strategy: merge  # merge | squash (default: merge)
+notes: |
+  Any context for the merge.
+```
+
+## Format B: One-liner
+```
+dev --strategy squash --notes "ready for review"
+```
+
+---
+
+## Rules
+1. Must be on a `feature/<slug>`, `bugfix/<slug>`, or `refactor/<slug>` branch
+2. All tests must pass before merge
+3. Working directory must be clean (no uncommitted changes)
+4. Local only (no push unless explicitly requested)
+5. Create merge commit with descriptive message
+
+## Type Detection
+Detect from current branch:
+- `feature/<slug>` → feature
+- `bugfix/<slug>` → bugfix
+- `refactor/<slug>` → refactor
+
+---
+
+## Steps
+
+### Step 1: Parse $ARGUMENTS
+Extract:
+- target (required, target branch name)
+- strategy (optional, default: merge)
+- notes (optional)
+
+### Step 2: Pre-merge checks
+1. Verify current branch is `feature/`, `bugfix/`, or `refactor/`
+2. Check working directory is clean:
+   ```bash
+   git status --porcelain
+   ```
+3. Verify all changes are committed
+4. Detect affected files:
+   ```bash
+   git diff --name-only <target>...HEAD
+   ```
+
+### Step 3: Run tests
+```bash
+docker compose exec be python manage.py test
+```
+
+### Step 4: Fetch and check target branch
+1. Fetch latest from remote (if exists):
+   ```bash
+   git fetch origin <target> 2>/dev/null || echo "Remote branch not found, using local"
+   ```
+2. Verify target branch exists locally:
+   ```bash
+   git rev-parse --verify <target>
+   ```
+
+### Step 5: Perform merge
+1. Switch to target branch:
+   ```bash
+   git checkout <target>
+   ```
+2. Merge based on strategy:
+   
+   **For merge strategy:**
+   ```bash
+   git merge <source-branch> -m "$(cat <<'EOF'
+   Merge <type>/<slug> into <target>
+   
+   <summary of changes>
+   EOF
+   )"
+   ```
+   
+   **For squash strategy:**
+   ```bash
+   git merge --squash <source-branch>
+   git commit -m "$(cat <<'EOF'
+   <type>(<slug>): <summary>
+   
+   <detailed changes>
+   EOF
+   )"
+   ```
+
+### Step 6: Handle conflicts (if any)
+If conflicts occur:
+1. List conflicted files
+2. Ask user how to proceed:
+   - Resolve conflicts manually
+   - Abort merge and return to source branch
+3. After resolution:
+   ```bash
+   git add <resolved-files>
+   git commit
+   ```
+
+### Step 7: Post-merge verification
+1. Run tests on target branch
+2. Verify application runs correctly:
+   ```bash
+   docker compose up -d
+   docker compose ps
+   ```
+
+### Step 8: Update spec documentation
+1. Update `agent-os/specs/<YYYY-MM-DD>-<slug>/spec.md` if needed:
+   - Add note about merge completion
+2. Update `agent-os/specs/<YYYY-MM-DD>-<slug>/tasks.md`:
+   - Add final merge entry
+
+### Step 9: Cleanup prompt
+Ask user if they want to:
+- Delete the source branch locally
+- Keep the source branch for reference
+
+---
+
+## Output
+
+```
+## Merge Complete
+
+### Branch Info
+- Source: <type>/<slug>
+- Target: <target>
+- Strategy: <strategy>
+
+### Status
+- Merge: ✓ Successful / ✗ Conflicts resolved
+- Tests: ✓ All passing
+
+### Next Steps
+- Push to remote? (y/n)
+- Delete source branch? (y/n)
+```
+
+---
+
+## IMPORTANT
+**DO NOT automatically push to remote.** Always ask the user:
+> "Merge complete. Ready to push `<target>` to remote?"
+
+Wait for explicit user confirmation before pushing.

--- a/.claude/commands/onboard.md
+++ b/.claude/commands/onboard.md
@@ -1,0 +1,238 @@
+---
+description: Onboard project. Reads scope docs and sets up agent-os structure.
+---
+
+# /onboard
+
+## Step 0: Check if Already Onboarded
+
+**Run these checks IN PARALLEL:**
+
+1. Check `CLAUDE.md` exists and has "## Stack" section
+2. Check `agent-os/product/roadmap.md` exists
+3. Check `agent-os/standards/index.yml` exists
+4. Check `agent-os/config.yml` exists
+
+**If ALL exist:**
+```
+✓ Already onboarded. Skipping.
+
+To refresh docs, run: /re-onboard
+To check project status, run: /query "current status"
+```
+**Exit early - do not proceed.**
+
+**If ANY missing:** Continue with Step 1.
+
+---
+
+## Step 1: Repo Discovery (Parallel)
+
+### Batch A: Core Config Files
+```
+PARALLEL:
+- Read: pyproject.toml
+- Read: docker-compose.yaml
+- Read: manage.py
+- Read: example.env
+```
+
+### Batch B: Structure Discovery
+```
+PARALLEL:
+- List: apps/
+- List: config/
+- List: scope/
+```
+
+### Batch C: Scope Documents (Product Context)
+```
+PARALLEL:
+- List: scope/*.md (discover all scope documents)
+- Read: ALL .md files found in scope/ folder
+```
+
+Known scope documents (read if present):
+- `scope/scope.md` - Project goals and features
+- `scope/prd.md` - Product requirements
+- `scope/ui_user_flow.md` - UI screens and flow
+- `scope/mvp_checklist.md` - MVP phases
+- Any other `.md` files discovered
+
+---
+
+## Step 2: Understand Product Context
+
+From scope documents, extract:
+
+### From scope/prd.md
+- Product overview and problem statement
+- Target users
+- Core user flow
+- Functional requirements
+- Non-functional requirements
+- Explicit non-goals
+
+### From scope/ui_user_flow.md
+- Design principles
+- Screen-by-screen flow
+- UI elements per screen
+- Error states
+
+### From scope/mvp_checklist.md
+- MVP phases and tasks
+- Current progress status
+
+### From scope/scope.md
+- Goals (primary and secondary)
+- Out of scope items
+- Feature list
+- Success criteria
+
+---
+
+## Step 3: Identify Services
+
+| Service | Path | Stack | Port |
+|---------|------|-------|------|
+| Django Backend | `apps/`, `config/` | Django 4.2, DRF, Celery | 8001 |
+| Celery Worker | (shared with Django) | Celery, RabbitMQ | N/A |
+| Celery Beat | (shared with Django) | Celery | N/A |
+
+---
+
+## Step 4: Update CLAUDE.md
+
+Create/update with:
+- Product overview (from scope/prd.md)
+- Stack overview (all services)
+- Docker commands per service
+- Test commands per service
+- Migration commands
+- Project structure
+
+---
+
+## Step 5: Setup agent-os structure
+
+Ensure directories exist:
+- `agent-os/`
+- `agent-os/product/`
+- `agent-os/specs/`
+- `agent-os/standards/`
+
+Create `agent-os/config.yml` if missing:
+```yaml
+version: 3.0
+last_compiled: <today>
+
+# ================================================
+# Project - Agent OS Configuration
+# ================================================
+profile: default
+product_name: <project-name>
+product_type: <project-type>
+description: <project description from scope docs>
+```
+
+---
+
+## Step 6: Initialize Product Roadmap
+
+Create `agent-os/product/roadmap.md` from scope documents:
+- Import phases from `scope/mvp_checklist.md`
+- Import features from `scope/scope.md`
+- Import user flow from `scope/ui_user_flow.md`
+- Map to implementation tasks
+
+---
+
+## Step 7: Verify Docker Setup
+
+```bash
+# Build all services
+docker compose build
+
+# Start all services
+docker compose up -d
+
+# Check service status
+docker compose ps
+
+# Verify Django
+docker compose exec be python manage.py check
+docker compose exec be python manage.py migrate
+```
+
+---
+
+## Step 8: Verify Test Harnesses
+
+### Django Tests
+```bash
+docker compose exec be python manage.py test
+```
+
+If no tests exist, note as blocker.
+
+---
+
+## Step 9: Check agent-os Standards
+
+Verify `agent-os/standards/` structure exists.
+
+If missing, recommend running `/init-standards`.
+
+---
+
+## Step 10: Document Workflow
+
+Add to CLAUDE.md:
+- Branch naming: `feature/<slug>`, `bugfix/<slug>`, `refactor/<slug>`
+- Local commits only
+- E2E testing with Docker
+- Spec location: `agent-os/specs/<YYYY-MM-DD>-<slug>/`
+
+---
+
+## Output
+
+```
+## Onboard Complete
+
+### Product: <project-name>
+<product description from scope docs>
+
+### Scope Documents Loaded
+(List all .md files discovered in scope/ folder)
+- [x] scope/scope.md - Project goals and features
+- [x] scope/prd.md - Product requirements
+- [x] scope/ui_user_flow.md - UI screens and flow
+- [x] scope/mvp_checklist.md - MVP phases
+- [x] (any other .md files found)
+
+### Services Discovered
+| Service | Status | Tests |
+|---------|--------|-------|
+| Django Backend | ✓ Running | ✓ X tests |
+| Celery Worker | ✓ Running | - |
+| Celery Beat | ✓ Running | - |
+
+### Docker Status
+- All services: [running/issues]
+- Ports: 8001 (Django)
+
+### Agent OS Structure
+- [x] agent-os/config.yml
+- [x] agent-os/product/roadmap.md
+- [x] agent-os/standards/index.yml
+- [x] agent-os/specs/
+
+### Blockers
+- (list any issues)
+
+### Next Steps
+- /query "<topic>" - Explore codebase
+- /init-project-roadmap - Create/update roadmap from scope docs
+- /init-standards - Setup coding standards
+```

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -1,0 +1,193 @@
+---
+description: Plan work and update the spec. No code edits. Works with features, bugfixes, and refactors.
+---
+
+# /plan
+
+Input: $ARGUMENTS
+
+## Format A (Preferred): YAML block
+```
+slug: user-export
+type: feature  # feature | bugfix | refactor (auto-detected from branch if omitted)
+notes: |
+  Any extra context for planning.
+```
+
+## Format B: One-liner
+```
+user-export --type feature --notes "prioritize API design"
+```
+
+---
+
+## Rules
+- No code edits
+- Update spec only
+- **MUST use `AskUserQuestion` tool for interactive planning** - do not assume, ask the user
+- Auto-detect type from current branch if not specified
+
+## Type Detection
+If `type` not provided, detect from current branch:
+- `feature/<slug>` → feature
+- `bugfix/<slug>` → bugfix
+- `refactor/<slug>` → refactor
+
+## Path Mapping
+| Type | Branch | Spec Folder |
+|------|--------|-------------|
+| feature | `feature/<slug>` | `agent-os/specs/<YYYY-MM-DD>-<slug>/` |
+| bugfix | `bugfix/<slug>` | `agent-os/specs/<YYYY-MM-DD>-<slug>/` |
+| refactor | `refactor/<slug>` | `agent-os/specs/<YYYY-MM-DD>-<slug>/` |
+
+### Finding Existing Specs
+To find an existing spec folder by slug:
+```bash
+ls agent-os/specs/ | grep <slug>
+```
+
+---
+
+## Steps
+
+### Step 1: Parse $ARGUMENTS
+Extract:
+- slug (required, lowercase, hyphen-separated)
+- type (optional, auto-detected)
+- notes (optional)
+
+### Step 2: Determine type and paths
+1. If type not provided, detect from current branch
+2. Find existing spec folder
+3. Set paths based on found folder
+
+### Step 3: Read context
+1. Read `CLAUDE.md` + `agent-os/standards/`
+2. Open spec file, requirements, and `planning/raw-idea.md` (if exists)
+3. **CRITICAL: Use the `AskUserQuestion` tool** to interview me interactively.
+
+#### Interview Process (REQUIRED)
+You MUST use `AskUserQuestion` to ask questions ONE AT A TIME. Do not proceed without user input.
+
+**Question Categories** (ask as needed):
+- What areas of the codebase are affected?
+- Preferred folder and module structure
+- Technical implementation approach
+- API design
+- UI and UX (if applicable)
+- Concerns and tradeoffs
+- Design decisions
+- Implementation order
+
+Wait for my response before asking the next question. Continue until you have enough context to write the spec.
+
+### Step 4: Update spec based on type
+
+#### For Features:
+- Executive Summary
+- Problem Statement
+- Goals & Success Criteria
+- Technical Design (models, views, URLs, Celery tasks)
+- Testing Strategy
+
+#### For Bugfixes:
+- Problem Statement
+- Root Cause Analysis
+- Proposed Fix
+- Testing Strategy (regression, unit, integration)
+- Success Criteria
+
+#### For Refactors:
+- Problem Statement
+- Current State vs Target State
+- Safety Net (existing tests, tests to add)
+- Refactor Strategy
+- Files Affected
+- Testing Strategy
+- Rollback Plan
+
+### Step 5: Create orchestration.yml
+
+```yaml
+task_groups:
+  - name: <Task Group 1 Name>
+    claude_code_subagent: general-purpose
+  - name: <Task Group 2 Name>
+    claude_code_subagent: general-purpose
+```
+
+### Step 6: Create tasks.md
+
+```markdown
+# Task Breakdown: <Title>
+
+**Spec**: `<YYYY-MM-DD>-<slug>`
+**Status**: Ready for Implementation
+
+## Task List
+
+### Task Group 1: <Group Name>
+
+**Priority**: High | Medium | Low
+**Files**:
+- `<path/to/file1>`
+
+#### Subtasks:
+
+**1.1 <Subtask Name>**
+- [ ] Step 1
+- [ ] Step 2
+
+**Acceptance Criteria**:
+- <criterion 1>
+
+---
+
+## Execution Order
+
+1. **<Group 1>**
+2. **<Group 2>**
+
+---
+
+## Key Implementation Notes
+
+### Patterns to Follow
+- 
+
+### Risk Mitigation
+- 
+
+---
+
+## Dependencies
+
+**External Dependencies:**
+- 
+
+**Internal Dependencies:**
+- 
+```
+
+### Step 7: Finalize
+1. Update spec Status section if present
+2. Output plan summary
+
+---
+
+## Output
+- Updated spec saved
+- orchestration.yml created/updated
+- tasks.md created/updated
+- Short summary of changes made
+
+## Next Commands
+- `/execute <slug>` - Start fresh implementation
+- `/resume-execute <slug>` - Resume from tasks.md
+- `/progress-status <slug>` - Check progress
+
+## IMPORTANT
+**DO NOT automatically run `/execute`.** Always ask the user:
+> "Planning complete. Ready to run `/execute <slug>`?"
+
+Wait for explicit user confirmation before proceeding.

--- a/.claude/commands/pr-address.md
+++ b/.claude/commands/pr-address.md
@@ -1,0 +1,324 @@
+---
+description: Create a plan to address PR review feedback - either code changes or reply comments.
+---
+
+# /pr-address
+
+Input: $ARGUMENTS
+
+## Format A: PR number
+```
+123
+```
+
+## Format B: PR number with options
+```
+123 --mode plan  # plan | execute (default: plan)
+```
+
+---
+
+## Rules
+1. First fetches all review feedback (like `/pr-reviews`)
+2. Analyzes each piece of feedback to determine appropriate response
+3. Creates actionable plan with two categories:
+   - **Code Changes** - Items requiring actual code modifications
+   - **Replies** - Items that need explanation/clarification only
+4. In `plan` mode: shows the plan for user approval
+5. In `execute` mode: implements changes and drafts replies (after plan approval)
+
+---
+
+## Steps
+
+### Step 1: Parse $ARGUMENTS
+Extract:
+- PR number (required)
+- mode (optional, default: plan)
+
+### Step 2: Fetch PR and review data
+Run the same data gathering as `/pr-reviews`:
+```bash
+# PR info
+gh pr view <number> --json number,title,state,baseRefName,headRefName,author,url,body
+
+# Reviews
+gh pr view <number> --json reviews
+
+# Inline comments
+gh api repos/{owner}/{repo}/pulls/<number>/comments
+
+# General comments  
+gh pr view <number> --json comments
+```
+
+### Step 3: Analyze each feedback item
+For each comment/review, determine:
+
+**Requires Code Change if:**
+- Points to specific code issue (bug, missing validation, etc.)
+- Requests new functionality or tests
+- Identifies security or performance problem
+- Uses imperative language: "fix", "add", "remove", "change"
+- References specific line numbers with issues
+
+**Requires Reply Only if:**
+- Asks a question about design decision
+- Requests clarification on approach
+- Is a "nit" or style preference that's subjective
+- Already addressed in another commit
+- Based on misunderstanding of requirements
+- Is praise or acknowledgment ("LGTM", "nice!")
+
+### Step 4: Cross-reference with codebase
+For code change requests:
+1. Read the referenced file(s)
+2. Understand the current implementation
+3. Determine if change is valid and necessary
+4. Estimate complexity (simple/medium/complex)
+
+### Step 5: Generate the plan
+
+```markdown
+## PR Feedback Response Plan: #<number>
+
+### Summary
+- Total feedback items: X
+- Code changes needed: Y
+- Replies needed: Z
+
+---
+
+## 🔧 Code Changes Required
+
+### Change 1: <brief description>
+**Source:** @reviewer - "original comment"
+**File:** `apps/models.py:45`
+**Action:** Add database index for `user_id` field
+**Complexity:** Simple
+**Implementation:**
+```python
+# Add to Meta class
+indexes = [
+    models.Index(fields=['user_id']),
+]
+```
+
+### Change 2: <brief description>
+**Source:** @reviewer - "original comment"
+**File:** `apps/views.py:123`
+**Action:** Add authentication check before processing
+**Complexity:** Medium
+**Implementation:**
+- Add `IsAuthenticated` permission class
+- Update view to check user ownership
+
+---
+
+## 💬 Replies to Draft
+
+### Reply 1: Design decision explanation
+**To:** @reviewer
+**Original:** "Why did you choose X over Y?"
+**Suggested Reply:**
+> Good question! I chose X because [reason]. The spec in `agent-os/specs/.../spec.md` discusses this in the Architecture section. Y would have required [tradeoff] which didn't fit our requirements for [goal].
+
+### Reply 2: Clarification
+**To:** @reviewer  
+**Original:** "Is this timeout sufficient?"
+**Suggested Reply:**
+> Yes, the 30s timeout is based on our p99 latency measurements. We have retry logic in `apps/tasks.py` that handles longer operations. Happy to increase if you've seen issues in testing.
+
+### Reply 3: Acknowledge nit
+**To:** @reviewer
+**Original:** "Nit: consider f-strings"
+**Suggested Reply:**
+> Good catch! Fixed in the upcoming commit.
+
+### Reply 4: Already addressed
+**To:** @reviewer
+**Original:** "Add error handling here"
+**Suggested Reply:**
+> This is handled by the `@handle_errors` decorator on line 45. The decorator catches and logs all exceptions, returning a standardized error response.
+
+---
+
+## ✅ No Action Needed
+
+### Item 1
+**From:** @reviewer - "LGTM, nice clean implementation!"
+**Reason:** Approval/praise, no response needed
+
+---
+
+## Execution Order
+
+1. [ ] Implement Change 1 (index)
+2. [ ] Implement Change 2 (auth check)
+3. [ ] Run tests to verify changes
+4. [ ] Commit with message: `fix(pr-feedback): address review comments`
+5. [ ] Post replies to PR
+6. [ ] Push changes
+7. [ ] Re-request review
+
+---
+
+## Ready to Execute?
+Run `/pr-address <number> --mode execute` to implement this plan.
+```
+
+### Step 6: Execute mode (if requested)
+
+#### 6a: Implement code changes
+For each code change:
+1. Read the target file
+2. Make the required modification
+3. Verify no linter errors
+4. Stage the change
+
+#### 6b: Run tests
+```bash
+docker compose exec be python manage.py test <affected_app>
+```
+
+#### 6c: Commit changes
+```bash
+git add .
+git commit -m "$(cat <<'EOF'
+fix(pr-feedback): address review comments
+
+Changes:
+- <change 1 description>
+- <change 2 description>
+
+Addresses feedback from: @reviewer1, @reviewer2
+EOF
+)"
+```
+
+#### 6d: Post replies
+For each reply:
+```bash
+# Reply to inline comment
+gh api repos/{owner}/{repo}/pulls/<number>/comments/<comment_id>/replies \
+  -f body="<reply text>"
+
+# Reply to general comment
+gh pr comment <number> --body "<reply text>"
+```
+
+#### 6e: Push and notify
+```bash
+git push
+```
+
+---
+
+## Output (Plan Mode)
+
+```
+## PR Feedback Analysis Complete
+
+### #<number>: <title>
+
+| Category | Count |
+|----------|-------|
+| Code Changes | X |
+| Replies | Y |
+| No Action | Z |
+
+### Plan Generated
+<full plan as shown in Step 5>
+
+### Next Steps
+- Review the plan above
+- Run `/pr-address <number> --mode execute` to implement
+- Or make manual adjustments first
+```
+
+## Output (Execute Mode)
+
+```
+## PR Feedback Addressed
+
+### #<number>: <title>
+
+### Code Changes Made
+- ✅ Added index to `apps/models.py`
+- ✅ Added auth check to `apps/views.py`
+
+### Replies Posted
+- ✅ Replied to @reviewer1 about design decision
+- ✅ Replied to @reviewer2 about timeout
+- ✅ Acknowledged nit from @reviewer1
+
+### Commit
+- Hash: <commit_hash>
+- Message: "fix(pr-feedback): address review comments"
+
+### Tests
+- Status: ✅ All passing
+
+### Push Status
+- Pushed to: origin/<branch>
+
+### Next Steps
+- PR updated: <url>
+- Re-request review from reviewers
+- Monitor for additional feedback
+```
+
+---
+
+## Reply Templates
+
+### Design Decision
+> Thanks for the question! I chose this approach because [reason]. The alternative [X] would have [tradeoff]. See the spec at `agent-os/specs/.../spec.md` for more context on this decision.
+
+### Fixed
+> Good catch! Fixed in commit <hash>.
+
+### Already Handled
+> This is actually handled by [mechanism] in [location]. [Brief explanation of how].
+
+### Intentional
+> This is intentional - [explanation]. The reason is [justification]. Happy to discuss if you see issues with this approach.
+
+### Will Address Later
+> Agreed this would be an improvement. I've noted it for a follow-up PR since it's out of scope for this change. Created issue #<number> to track.
+
+### Disagree (Respectfully)
+> I see your point, but I think [current approach] is better here because [reason]. [Evidence/reference if available]. Open to discussing further if you have concerns.
+
+---
+
+## Error Handling
+
+### No actionable feedback
+```
+Info: All feedback has been addressed or requires no action.
+- X approvals received
+- No pending change requests
+
+PR is ready for merge!
+```
+
+### Conflicting feedback
+```
+Warning: Conflicting feedback from reviewers:
+- @user1 says: "Use approach A"
+- @user2 says: "Use approach B"
+
+Recommendation: Discuss in PR comments to reach consensus.
+```
+
+---
+
+## IMPORTANT
+In `execute` mode:
+- Always show the plan first and ask for confirmation
+- Never force-push or rewrite history
+- Post replies one at a time to avoid rate limiting
+- If tests fail after changes, stop and report
+
+> "Plan ready. Review above and confirm to proceed with execution."

--- a/.claude/commands/pr-create.md
+++ b/.claude/commands/pr-create.md
@@ -1,0 +1,164 @@
+---
+description: Create a Pull Request using GitHub CLI.
+---
+
+# /pr-create
+
+Input: $ARGUMENTS
+
+## Format A (Preferred): YAML block
+```
+title: Add notification system
+draft: false  # true | false (default: false)
+target: dev   # dev | custom (default: dev)
+reviewers: []  # optional list of GitHub usernames
+notes: |
+  Any extra context for the PR body.
+```
+
+## Format B: One-liner
+```
+--title "Add notification system" --draft --target dev --reviewers "user1,user2" --notes "..."
+```
+
+## Format C: Minimal (auto-generates title from commits)
+```
+# Just run /pr-create with no arguments
+```
+
+---
+
+## Rules
+1. Must be on a `feature/<slug>`, `bugfix/<slug>`, or `refactor/<slug>` branch
+2. Working directory should be clean (uncommitted changes will prompt commit first)
+3. Branch must be pushed to remote before creating PR
+4. Default target branch: `dev`
+
+---
+
+## Steps
+
+### Step 1: Parse $ARGUMENTS
+Extract:
+- title (optional, derived from commits/branch if not provided)
+- draft (optional, default: false)
+- target (optional, default: dev)
+- reviewers (optional, list of GitHub usernames)
+- notes (optional, additional context for PR body)
+
+### Step 2: Pre-flight checks
+1. Verify current branch is `feature/`, `bugfix/`, or `refactor/`:
+   ```bash
+   git branch --show-current
+   ```
+2. Check for uncommitted changes:
+   ```bash
+   git status --porcelain
+   ```
+   If changes exist, ask user if they want to commit first.
+3. Verify gh CLI is available:
+   ```bash
+   gh --version
+   ```
+
+### Step 3: Push branch to remote
+```bash
+git push -u origin HEAD
+```
+
+### Step 4: Generate PR title and body
+1. If title not provided, generate from:
+   - Branch type + slug: `feat(notification-app): implement notification system`
+   - Or from recent commit messages
+2. Generate PR body
+
+### Step 5: Gather commit information
+```bash
+# Get commits not in target branch
+git log origin/<target>..HEAD --oneline
+
+# Get full diff summary
+git diff origin/<target>...HEAD --stat
+```
+
+### Step 6: Create the Pull Request
+```bash
+gh pr create \
+  --title "<title>" \
+  --body "$(cat <<'EOF'
+## Summary
+<bullet points from commits or notes>
+
+## Changes
+<list of changed files>
+
+## Test Plan
+- [ ] Unit tests pass
+- [ ] Integration tests pass
+- [ ] Manual testing completed
+
+## Spec
+- `agent-os/specs/<date>-<slug>/spec.md`
+EOF
+)" \
+  --base <target> \
+  --head <current-branch> \
+  [--draft] \
+  [--reviewer <reviewers>]
+```
+
+### Step 7: Verify PR creation
+```bash
+gh pr view --json number,url,title,state
+```
+
+---
+
+## Output
+
+```
+## Pull Request Created
+
+### PR Info
+- Title: <title>
+- Number: #<number>
+- URL: <url>
+- Status: <Open | Draft>
+- Target: <target> ← <current-branch>
+
+### Changes Summary
+| Files | Additions | Deletions |
+|-------|-----------|-----------|
+| X | +Y | -Z |
+
+### Commits Included
+- <commit hash> <message>
+
+### Next Steps
+- `/pr-reviews <number>` - Fetch review feedback
+- View PR: <url>
+```
+
+---
+
+## Error Handling
+
+### Branch not pushed
+```
+Error: Branch not found on remote.
+Action: Pushing branch to origin...
+```
+
+### PR already exists
+```
+Warning: PR already exists for this branch.
+PR #<number>: <url>
+Action: Use `/pr-reviews <number>` to check status.
+```
+
+---
+
+## IMPORTANT
+**DO NOT automatically merge or approve.** The PR is created for review.
+After creation, suggest:
+> "PR created. Use `/pr-reviews <number>` to fetch review feedback when ready."

--- a/.claude/commands/pr-reviews.md
+++ b/.claude/commands/pr-reviews.md
@@ -1,0 +1,217 @@
+---
+description: Fetch review comments and change requests from a GitHub PR.
+---
+
+# /pr-reviews
+
+Input: $ARGUMENTS
+
+## Format A: PR number
+```
+123
+```
+
+## Format B: PR URL
+```
+https://github.com/owner/repo/pull/123
+```
+
+## Format C: Auto-detect (current branch)
+```
+# Run /pr-reviews with no arguments to find PR for current branch
+```
+
+---
+
+## Rules
+1. Requires GitHub CLI (`gh`) to be installed and authenticated
+2. Fetches all review comments, change requests, and general comments
+3. Organizes feedback by reviewer and type (approval, changes requested, comments)
+4. Identifies actionable items vs informational comments
+
+---
+
+## Steps
+
+### Step 1: Parse $ARGUMENTS
+Extract:
+- PR number (from direct input, URL, or current branch)
+
+### Step 2: Determine PR number
+1. If number provided directly, use it
+2. If URL provided, extract number from URL
+3. If no arguments, find PR for current branch:
+   ```bash
+   gh pr view --json number -q '.number' 2>/dev/null
+   ```
+
+### Step 3: Verify PR exists and get basic info
+```bash
+gh pr view <number> --json number,title,state,baseRefName,headRefName,author,url
+```
+
+### Step 4: Fetch all reviews
+```bash
+gh pr view <number> --json reviews --jq '.reviews[] | {author: .author.login, state: .state, body: .body, submittedAt: .submittedAt}'
+```
+
+Review states:
+- `APPROVED` - Reviewer approved the PR
+- `CHANGES_REQUESTED` - Reviewer requested changes
+- `COMMENTED` - Reviewer left comments without approval/rejection
+- `PENDING` - Review not yet submitted
+
+### Step 5: Fetch review comments (inline comments on code)
+```bash
+gh api repos/{owner}/{repo}/pulls/<number>/comments --jq '.[] | {
+  author: .user.login,
+  path: .path,
+  line: .line,
+  body: .body,
+  created_at: .created_at,
+  in_reply_to_id: .in_reply_to_id
+}'
+```
+
+### Step 6: Fetch general PR comments (conversation)
+```bash
+gh pr view <number> --json comments --jq '.comments[] | {author: .author.login, body: .body, createdAt: .createdAt}'
+```
+
+### Step 7: Organize and categorize feedback
+
+Group by:
+1. **Change Requests** - Items that MUST be addressed
+2. **Suggestions** - Optional improvements
+3. **Questions** - Clarifications needed
+4. **Approvals** - Positive feedback
+
+For each comment, categorize:
+- Has "LGTM", "looks good", "approved" → Approval
+- Has "must", "should", "need to", "please fix" → Change Request
+- Has "?", "wondering", "could you explain" → Question
+- Has "consider", "might", "optional", "nit" → Suggestion
+
+### Step 8: Map comments to files
+Group inline comments by file path for easier navigation:
+```
+apps/conversation/models.py
+  - Line 45: "Consider adding index" (@reviewer1)
+  - Line 89: "This should use select_related" (@reviewer2)
+```
+
+---
+
+## Output
+
+```
+## PR Review Summary: #<number>
+
+### PR Info
+- Title: <title>
+- Author: @<author>
+- Status: <state>
+- Branch: <head> → <base>
+- URL: <url>
+
+---
+
+### Review Status
+
+| Reviewer | Status | Date |
+|----------|--------|------|
+| @user1 | ✅ Approved | 2026-01-28 |
+| @user2 | 🔄 Changes Requested | 2026-01-28 |
+| @user3 | 💬 Commented | 2026-01-27 |
+
+---
+
+### 🔴 Change Requests (Must Address)
+
+#### From @reviewer1
+1. **apps/models.py:45** - "Add database index for query performance"
+2. **apps/views.py:123** - "Missing authentication check"
+
+#### From @reviewer2
+1. **General** - "Please add unit tests for the new service"
+
+---
+
+### 🟡 Suggestions (Consider)
+
+1. **apps/utils.py:67** (@reviewer1) - "Consider using f-strings here"
+2. **apps/tasks.py:89** (@reviewer2) - "Nit: variable naming"
+
+---
+
+### 🔵 Questions (Need Response)
+
+1. (@reviewer1) - "Why did you choose this approach over X?"
+2. **apps/services.py:34** (@reviewer2) - "Is this timeout sufficient for production?"
+
+---
+
+### 💬 General Comments
+
+- @reviewer1: "Overall good structure, just a few minor things"
+- @reviewer3: "Tested locally, works well"
+
+---
+
+### Approvals
+
+- ✅ @user1: "LGTM!"
+
+---
+
+### Next Steps
+- `/pr-address <number>` - Create plan to address feedback
+- Address changes and push updates
+- Re-request review when ready
+```
+
+---
+
+## Detailed Comment View
+
+If user requests more detail on a specific comment:
+
+```bash
+gh api repos/{owner}/{repo}/pulls/<number>/comments/<comment_id>
+```
+
+---
+
+## Error Handling
+
+### PR not found
+```
+Error: PR #<number> not found.
+- Check the PR number is correct
+- Ensure you have access to this repository
+```
+
+### No reviews yet
+```
+Info: PR #<number> has no reviews yet.
+- PR may be newly created
+- Consider requesting reviewers via GitHub UI or:
+  gh pr edit <number> --add-reviewer <username>
+```
+
+### No PR for current branch
+```
+Error: No PR found for branch '<branch>'.
+- Create a PR first: `/pr-create`
+- Or specify PR number: `/pr-reviews 123`
+```
+
+---
+
+## IMPORTANT
+This command is READ-ONLY. It fetches and organizes review feedback but does not:
+- Respond to comments
+- Make code changes
+- Resolve conversations
+
+Use `/pr-address <number>` to create a plan for addressing the feedback.

--- a/.claude/commands/progress-init.md
+++ b/.claude/commands/progress-init.md
@@ -1,0 +1,141 @@
+---
+description: Initialize task tracking. Standalone utility if /plan wasn't used.
+---
+
+# /progress-init
+
+Input: $ARGUMENTS
+
+## Format
+```
+<slug> --type <type>
+```
+
+Type: `feature`, `bugfix`, `refactor` (auto-detected from branch if omitted)
+
+---
+
+## Rules
+- Use when tasks.md doesn't exist yet
+- Note: `/plan` already creates tasks.md automatically
+- This is a standalone utility for manual initialization
+
+---
+
+## Steps
+
+### 1. Verify spec exists
+Find spec folder:
+```bash
+ls agent-os/specs/ | grep <slug>
+```
+
+Check that exists:
+- `agent-os/specs/<YYYY-MM-DD>-<slug>/spec.md`
+
+If not found, recommend running `/plan <slug>` first.
+
+### 2. Read spec to identify scope
+Parse spec for:
+- Success Criteria sections
+- Technical Design sections
+
+### 3. Create orchestration.yml
+Create `agent-os/specs/<YYYY-MM-DD>-<slug>/orchestration.yml`:
+
+```yaml
+task_groups:
+  - name: <Task Group 1 Name>
+    claude_code_subagent: general-purpose
+  - name: <Task Group 2 Name>
+    claude_code_subagent: general-purpose
+```
+
+### 4. Create tasks.md
+Create `agent-os/specs/<YYYY-MM-DD>-<slug>/tasks.md`:
+
+```markdown
+# Task Breakdown: <Name>
+
+**Spec**: `<YYYY-MM-DD>-<slug>`
+**Status**: Ready for Implementation
+
+## Overview
+Total Tasks: X task groups with Y sub-tasks
+
+## Task List
+
+### Task Group 1: <Group Name>
+
+**Priority**: High | Medium | Low
+**Files**:
+- `<path/to/file1>`
+
+#### Subtasks:
+
+**1.1 <Subtask Name>**
+- [ ] Step 1
+- [ ] Step 2
+
+**Acceptance Criteria**:
+- <criterion 1>
+
+---
+
+## Execution Order
+
+1. **<Group 1>** - X days
+2. **<Group 2>** - X days
+
+---
+
+## Key Implementation Notes
+
+### Patterns to Follow
+- 
+
+### File References
+**Files to Modify:**
+- 
+
+**Test Files to Create:**
+- 
+
+### Risk Mitigation
+- 
+
+---
+
+## Dependencies
+
+**External Dependencies:**
+- 
+
+**Internal Dependencies:**
+- 
+```
+
+### 5. Extract tasks from spec
+- Parse implementation sections from spec
+- Populate tasks.md task groups
+
+---
+
+## Output
+
+```
+## Progress Initialized
+
+### <Type>: <slug>
+- Folder: agent-os/specs/<YYYY-MM-DD>-<slug>/
+- Orchestration: agent-os/specs/<YYYY-MM-DD>-<slug>/orchestration.yml
+- Tasks doc: agent-os/specs/<YYYY-MM-DD>-<slug>/tasks.md
+- Spec: agent-os/specs/<YYYY-MM-DD>-<slug>/spec.md
+
+### Total Tasks
+- **Total:** X tasks
+
+### Next Steps
+- /execute <slug> - Start implementation
+- /resume-execute <slug> - Resume from progress
+```

--- a/.claude/commands/progress-reset.md
+++ b/.claude/commands/progress-reset.md
@@ -1,0 +1,86 @@
+---
+description: Reset task tracking for feature/bugfix/refactor. Clears tasks and keeps spec intact.
+---
+
+# /progress-reset
+
+Input: $ARGUMENTS
+
+## Format
+```
+<slug> --type <type> --hard
+```
+
+- Type: `feature`, `bugfix`, `refactor` (auto-detected from branch if omitted)
+- `--hard`: Also reset git branch (destructive)
+
+---
+
+## Rules
+- Preserves spec.md (no changes to requirements)
+- Resets tasks.md to initial state
+- Does NOT delete git commits (use `--hard` flag for that)
+- Requires confirmation before reset
+
+---
+
+## Steps
+
+### 1. Confirm tasks.md exists
+Find spec folder:
+```bash
+ls agent-os/specs/ | grep <slug>
+```
+
+Check `agent-os/specs/<YYYY-MM-DD>-<slug>/tasks.md` exists.
+If not, error: "No task tracking found for <slug>"
+
+### 2. Show current progress
+Display before reset:
+```
+## Current Progress: <slug>
+
+| Progress | Tasks |
+|----------|-------|
+| X% | X/Y |
+```
+
+### 3. Confirm reset with user
+Ask: "Reset progress for <slug>? This will clear all task checkmarks."
+
+### 4. Reset tasks.md
+- Uncheck all tasks: `[x]` → `[ ]`
+- Keep task list structure intact
+
+### 5. If `--hard` flag specified
+- Warning: "This will also reset git branch to base"
+- Confirm again
+- Run: `git reset --hard origin/dev`
+- Note: Destructive, cannot be undone
+
+---
+
+## Output
+
+```
+## Progress Reset Complete
+
+### <Type>: <slug>
+
+#### Before
+| Progress |
+|----------|
+| X% |
+
+#### After
+| Progress |
+|----------|
+| 0% |
+
+### Tasks Cleared
+- **Total:** X tasks
+
+### Next Steps
+- /execute <slug> - Start fresh implementation
+- /plan <slug> - Review/update spec first
+```

--- a/.claude/commands/progress-status.md
+++ b/.claude/commands/progress-status.md
@@ -1,0 +1,111 @@
+---
+description: Show progress status for features/bugfixes/refactors. Quick overview of implementation state.
+---
+
+# /progress-status
+
+Input: $ARGUMENTS (optional, shows all if empty)
+
+## Format
+```
+<slug> --type <type>
+```
+
+Type: `feature`, `bugfix`, `refactor`, `all` (default: auto-detect or `all`)
+
+---
+
+## Rules
+- Read-only command
+- Summarizes progress across features/bugfixes/refactors
+
+---
+
+## Steps
+
+### 1. If slug specified:
+- Detect type from branch or argument
+- Find spec folder: `ls agent-os/specs/ | grep <slug>`
+- Read `agent-os/specs/<YYYY-MM-DD>-<slug>/tasks.md`
+- Show detailed status
+
+### 2. If no slug specified:
+- Scan all spec folders in `agent-os/specs/`
+- Read each tasks.md file
+- Show summary table
+
+### 3. Calculate metrics:
+- Total tasks
+- Completed tasks
+- Overall progress percentage
+- Blockers count
+
+---
+
+## Output Format
+
+### Single Feature/Bugfix/Refactor
+```
+## <Name>
+
+**Type:** Feature | Bugfix | Refactor
+**Status:** In Progress
+**Branch:** <type>/<slug>
+**Spec Folder:** agent-os/specs/<YYYY-MM-DD>-<slug>/
+
+### Overall Progress
+Progress: 8/10 tasks (80%)
+
+### Completed Tasks
+  ✓ Models created
+  ✓ Migrations applied
+  ✓ Views implemented
+
+### Remaining Tasks
+  ○ Unit tests
+  ○ Integration tests
+
+### Blockers
+  ⚠ <blocker description>
+```
+
+### All Items Summary
+```
+## Active Specs in agent-os/specs/
+
+### Features (<count>)
+| Folder | Status | Progress | Last Updated |
+|--------|--------|----------|--------------|
+| 2026-01-21-user-export | In Progress | 60% | 2026-01-20 |
+
+### Bugfixes (<count>)
+| Folder | Status | Progress | Last Updated |
+|--------|--------|----------|--------------|
+| 2026-01-22-login-timeout | In Progress | 80% | 2026-01-22 |
+
+### Refactors (<count>)
+| Folder | Status | Progress | Last Updated |
+|--------|--------|----------|--------------|
+| 2026-01-18-auth-service | In Progress | 40% | 2026-01-18 |
+
+## Summary
+- Features: X in progress, Y complete
+- Bugfixes: X open, Y fixed
+- Refactors: X in progress, Y complete
+- Total blockers: Z
+```
+
+---
+
+## Quick Filters
+
+```bash
+# Show only features
+/progress-status --type feature
+
+# Show only bugfixes
+/progress-status --type bugfix
+
+# Show specific item
+/progress-status user-export
+```

--- a/.claude/commands/query.md
+++ b/.claude/commands/query.md
@@ -1,0 +1,199 @@
+---
+description: Ask questions about this project - features, bugs, roadmap, architecture, or codebase. Read-only exploration. Fast parallel search.
+---
+
+# /query
+
+Input: $ARGUMENTS
+
+## Rules
+- Read-only command - no code edits
+- Use parallel searches for speed
+- Provide concise, accurate answers with references
+- If answer not found, say so explicitly
+
+---
+
+## Step 1: Classify Question (FAST)
+
+Detect category from keywords:
+
+| Category | Keywords |
+|----------|----------|
+| Features | feature, implement, planned, status, spec, what does X do |
+| Bugs | bug, fix, error, issue, broken, not working |
+| Roadmap | roadmap, phase, milestone, next, progress, timeline |
+| Architecture | how, architecture, flow, design, structure, pattern |
+| Code | where, find, located, function, class, file, module |
+| Status | status, progress, complete, done, remaining |
+| Standards | standard, convention, pattern, rule, guideline |
+
+**Multiple categories?** Search all in parallel.
+
+---
+
+## Step 2: Parallel Search Strategy
+
+Execute searches **IN PARALLEL** based on category:
+
+### For Features/Specs:
+```
+PARALLEL:
+- List: agent-os/specs/*/
+- Read: agent-os/product/roadmap.md
+- Grep: "<keyword>" in agent-os/specs/
+```
+
+### For Bugs:
+```
+PARALLEL:
+- List: agent-os/specs/*/ (look for bugfix in folder names)
+- Grep: "<keyword>" in agent-os/specs/
+```
+
+### For Roadmap:
+```
+PARALLEL:
+- Read: agent-os/product/roadmap.md
+- Read: agent-os/product/mission.md
+- Read: CLAUDE.md (first 100 lines)
+```
+
+### For Architecture:
+```
+PARALLEL:
+- Read: CLAUDE.md
+- Read: agent-os/product/tech-stack.md
+- Read: agent-os/standards/global/tech-stack.md
+```
+
+### For Code:
+```
+PARALLEL:
+- Grep: "<symbol>" in apps/
+- Grep: "<symbol>" in config/
+- Read: CLAUDE.md
+```
+
+### For Status:
+```
+PARALLEL:
+- Read: agent-os/product/roadmap.md
+- List: agent-os/specs/*/tasks.md
+```
+
+### For Standards:
+```
+PARALLEL:
+- Read: agent-os/standards/index.yml
+- List: agent-os/standards/
+- Read: agent-os/standards/<category>/<file>.md
+```
+
+---
+
+## Step 3: Quick Scan (if needed)
+
+If initial search insufficient, do targeted follow-up:
+
+| Need | Action |
+|------|--------|
+| Spec details | Read `agent-os/specs/<YYYY-MM-DD>-<slug>/spec.md` |
+| Task progress | Read `agent-os/specs/<YYYY-MM-DD>-<slug>/tasks.md` |
+| Implementation | Read source file in `apps/` |
+| Standard details | Read `agent-os/standards/<category>/<file>.md` |
+
+---
+
+## Step 4: Synthesize Answer
+
+Format based on question type:
+
+### Status Questions
+```
+## <Feature/Bug Name>
+Status: <status>
+Progress: <X/Y tasks> (<percent>%)
+Branch: <branch-name>
+Spec: agent-os/specs/<folder>/
+Last Updated: <date>
+```
+
+### List Questions
+```
+## <Category> (<count>)
+| Name | Status | Description |
+|------|--------|-------------|
+| ... | ... | ... |
+```
+
+### How/Where Questions
+```
+## Answer
+<direct answer>
+
+## Implementation
+| File | Key Functions |
+|------|---------------|
+| <path> | <list> |
+```
+
+### Standards Questions
+```
+## <Standard Name>
+
+### Summary
+<key points>
+
+### Location
+agent-os/standards/<category>/<file>.md
+
+### Key Rules
+- 
+- 
+```
+
+### General Questions
+```
+## Answer
+<concise answer>
+
+## References
+- <file1>
+- <file2>
+```
+
+---
+
+## Fallback Handling
+
+If answer not found:
+1. State explicitly: "No information found for <topic>"
+2. Suggest where info might be added
+3. Recommend commands to create the info:
+   - `/plan <slug>` - Create feature/bug spec
+   - `/onboard` - Refresh project docs
+   - `/re-onboard` - Update existing docs
+   - `/init-standards` - Setup standards
+
+---
+
+## Output
+
+Always include:
+- **Direct answer** (first line)
+- **References** (files consulted)
+- **Suggested Commands** (if actionable)
+
+Omit sections if empty (no "Related: None").
+
+---
+
+## Performance Tips
+
+1. **Prefer grep over read** for keyword searches
+2. **List directories first** before reading files
+3. **Parallel everything** that doesn't depend on prior results
+4. **Cache CLAUDE.md** - read once, reference often
+5. **Stop early** when answer found - don't over-search
+6. **Use agent-os/** - specs, standards, and product info are centralized there

--- a/.claude/commands/re-onboard.md
+++ b/.claude/commands/re-onboard.md
@@ -1,0 +1,266 @@
+---
+description: Refresh codebase understanding. Parallel scanning. Syncs with scope docs.
+---
+
+# /re-onboard
+
+## Rules
+- Assumes `/onboard` was run previously
+- Preserves existing docs, updates with changes
+- Non-destructive (adds, doesn't remove without confirmation)
+- Use parallel scans for speed
+- Syncs with scope/ documents for product context
+
+---
+
+## Step 1: Parallel Discovery
+
+Execute ALL discovery tasks **IN PARALLEL**:
+
+### Batch A: Read Existing Docs
+```
+PARALLEL:
+- Read: CLAUDE.md
+- Read: agent-os/config.yml
+- Read: agent-os/product/roadmap.md
+- Read: agent-os/standards/index.yml
+```
+
+### Batch B: Scope Documents (Product Context)
+```
+PARALLEL:
+- List: scope/*.md (discover all scope documents)
+- Read: ALL .md files found in scope/ folder
+```
+
+### Batch C: Django Backend Structure
+```
+PARALLEL:
+- List: apps/*/
+- List: config/
+- List: scripts/
+- List: tests/
+- Read: pyproject.toml (dependencies)
+- Read: docker-compose.yaml (services)
+- Read: example.env (env vars)
+```
+
+### Batch D: Scan Code Patterns (Django)
+```
+PARALLEL:
+- Grep: "class.*Model" in apps/*/models.py
+- Grep: "class.*Serializer" in apps/*/serializers.py
+- Grep: "class.*View\|class.*API" in apps/*/
+- Grep: "@shared_task" in apps/*/tasks.py
+- Grep: "path\(" in apps/*/urls.py
+```
+
+### Batch E: Check Recent Git Activity
+```
+PARALLEL:
+- git log --oneline -20 (recent commits)
+- git diff --stat HEAD~10 (files changed recently)
+- git branch -a (active branches)
+```
+
+### Batch F: Scan Active Specs
+```
+PARALLEL:
+- List: agent-os/specs/*/
+- Check for tasks.md in each spec folder
+```
+
+---
+
+## Step 2: Sync Scope Documents
+
+Compare scope/ docs with agent-os/ docs:
+
+### Scope Changes
+| Check | Source | Compare To |
+|-------|--------|------------|
+| Goals | scope/scope.md | agent-os/product/roadmap.md |
+| Features | scope/scope.md | agent-os/product/roadmap.md |
+| MVP Phases | scope/mvp_checklist.md | agent-os/product/roadmap.md |
+| User Flow | scope/ui_user_flow.md | agent-os/product/roadmap.md |
+| Requirements | scope/prd.md | CLAUDE.md |
+
+---
+
+## Step 3: Build Change Inventory
+
+Compare discovered vs documented:
+
+### Django Backend
+| Check | Source | Compare To |
+|-------|--------|------------|
+| Django apps | `apps/*/` listing | `CLAUDE.md` |
+| Models | Grep from models.py | CLAUDE.md models section |
+| Serializers | Grep from serializers.py | CLAUDE.md |
+| URL patterns | Grep from urls.py | CLAUDE.md |
+| Celery tasks | Grep @shared_task | CLAUDE.md |
+
+### Infrastructure
+| Check | Source | Compare To |
+|-------|--------|------------|
+| Docker services | docker-compose.yaml | `CLAUDE.md` |
+| Dependencies | pyproject.toml | `CLAUDE.md` |
+| Env vars | example.env | `CLAUDE.md` |
+
+### Active Specs
+| Check | Source | Compare To |
+|-------|--------|------------|
+| Spec folders | `agent-os/specs/*/` | Active branches |
+| Tasks progress | `tasks.md` files | Branch status |
+
+---
+
+## Step 4: Generate Diff Report
+
+Before updating, show what changed:
+
+```
+## Change Detection Report
+
+### SCOPE DOCUMENT CHANGES
+(List all .md files discovered in scope/ folder)
+- scope/scope.md: [modified/unchanged]
+- scope/prd.md: [modified/unchanged]
+- scope/ui_user_flow.md: [modified/unchanged]
+- scope/mvp_checklist.md: [modified/unchanged]
+- (any other .md files found): [status]
+
+### DJANGO BACKEND
+- NEW Apps: [list]
+- NEW Models: [list]
+- NEW Endpoints: [list]
+- NEW Tasks: [list]
+
+### INFRASTRUCTURE
+- NEW Docker services: [list]
+- NEW Dependencies: [list]
+- NEW Env vars: [list]
+
+### ACTIVE SPECS
+- In Progress: [list spec folders with incomplete tasks]
+- Recently Completed: [list]
+
+### MODIFIED (docs outdated)
+- [file]: [what changed]
+
+### REMOVED (in docs but not codebase)
+- [list - requires confirmation to remove from docs]
+
+### RECENT GIT ACTIVITY
+- Commits: [count] since [date]
+- Key changes: [summary]
+- Active branches: [list]
+
+Proceed with updates? (y/n)
+```
+
+**Wait for confirmation before updating docs.**
+
+---
+
+## Step 5: Update Documentation
+
+Update in this order (dependencies first):
+
+### 5.1 Update `CLAUDE.md`
+- Update product overview (if scope docs changed)
+- Update project structure section
+- Add new commands
+- Update environment variables
+- Update Docker services
+- Update test commands
+
+### 5.2 Update `agent-os/product/roadmap.md`
+- Sync with scope/mvp_checklist.md phases
+- Sync feature statuses from active specs
+- Mark completed features
+- Add untracked features to backlog
+- Update phase progress
+
+### 5.3 Update `agent-os/standards/index.yml`
+- Add descriptions for standards if missing
+- Note any new standards files discovered
+
+---
+
+## Step 6: Verify Environment
+
+```bash
+# Docker services
+docker compose ps
+
+# Django checks
+docker compose exec be python manage.py check
+docker compose exec be python manage.py showmigrations --list
+```
+
+Check for:
+- [ ] All Docker services running
+- [ ] No Django check errors
+- [ ] No unapplied migrations
+- [ ] No missing env vars
+
+---
+
+## Step 7: Validate Updates
+
+Quick verification:
+1. Re-read updated docs
+2. Spot-check 2-3 new items against code
+3. Ensure no formatting issues
+
+---
+
+## Output
+
+```
+## Re-onboard Complete
+
+### Product: <project-name>
+<product description from scope docs>
+
+### Scope Documents Status
+| Document | Status | Last Modified |
+|----------|--------|---------------|
+| scope/scope.md | [synced/updated] | [date] |
+| scope/prd.md | [synced/updated] | [date] |
+| scope/ui_user_flow.md | [synced/updated] | [date] |
+| scope/mvp_checklist.md | [synced/updated] | [date] |
+| (any other .md files found) | [status] | [date] |
+
+### Changes Detected
+| Category | New | Modified | Removed |
+|----------|-----|----------|---------|
+| Django Apps | X | X | X |
+| Django Models | X | X | X |
+| Django Endpoints | X | X | X |
+| Celery Tasks | X | X | X |
+
+### Documentation Updated
+- [x] CLAUDE.md (+X lines)
+- [x] agent-os/product/roadmap.md (X features synced)
+- [x] agent-os/standards/index.yml (X descriptions added)
+
+### Active Specs Status
+| Spec | Progress | Last Updated |
+|------|----------|--------------|
+| <spec-folder> | X% | <date> |
+
+### Environment Status
+- Docker: ✓ All services running
+- Django: ✓ No errors
+- Migrations: ✓ All applied
+
+### Issues Found
+- (none or list with severity)
+
+### Suggested Next Steps
+- /query "<topic>" - Explore specific area
+- /plan <slug> - Start next feature
+- /execute <slug> - Resume in-progress work
+```

--- a/.claude/commands/re-plan.md
+++ b/.claude/commands/re-plan.md
@@ -1,0 +1,98 @@
+---
+description: Remove existing spec files (preserving raw-idea.md) and start a fresh planning session from the original user prompt.
+---
+
+# /re-plan
+
+Input: $ARGUMENTS
+
+## Format
+```
+<slug>
+```
+
+Example: `user-export`
+
+---
+
+## Rules
+- No code edits
+- Delete spec files EXCEPT `planning/raw-idea.md`
+- Start fresh planning session using original prompt
+- Preserve the dated folder name
+
+---
+
+## Steps
+
+### Step 1: Parse $ARGUMENTS
+Extract:
+- slug (required, lowercase, hyphen-separated)
+
+### Step 2: Find existing spec folder
+```bash
+ls agent-os/specs/ | grep <slug>
+```
+
+If no folder found, abort with:
+> "No spec folder found for slug `<slug>`. Use `/feature-new`, `/bugfix-new`, or `/refactor` to create a new spec."
+
+### Step 3: Read raw-idea.md
+Read `agent-os/specs/<YYYY-MM-DD>-<slug>/planning/raw-idea.md`
+
+If file doesn't exist, warn:
+> "No raw-idea.md found. Planning will start without original context."
+
+### Step 4: Confirm deletion
+Ask user:
+> "Found spec folder `<folder-name>/`. This will delete:
+> - spec.md
+> - tasks.md
+> - orchestration.yml
+> - planning/requirements.md
+>
+> **PRESERVED:** planning/raw-idea.md (original prompt)
+>
+> Proceed with re-planning?"
+
+Wait for explicit confirmation.
+
+### Step 5: Delete spec files
+Delete the following files if they exist:
+- `agent-os/specs/<YYYY-MM-DD>-<slug>/spec.md`
+- `agent-os/specs/<YYYY-MM-DD>-<slug>/tasks.md`
+- `agent-os/specs/<YYYY-MM-DD>-<slug>/orchestration.yml`
+- `agent-os/specs/<YYYY-MM-DD>-<slug>/planning/requirements.md`
+
+**DO NOT DELETE:**
+- `agent-os/specs/<YYYY-MM-DD>-<slug>/planning/raw-idea.md`
+
+Keep the dated folder and planning/ folder.
+
+### Step 6: Start fresh planning with original context
+Run the `/plan` command, passing the original input from raw-idea.md:
+
+```
+slug: <slug>
+notes: |
+  [Original context from raw-idea.md]
+```
+
+The `/plan` command will:
+1. Detect type from current branch
+2. Read CLAUDE.md and standards
+3. Read the preserved raw-idea.md for original context
+4. Interview about requirements (starting from original prompt)
+5. Create fresh spec.md, tasks.md, orchestration.yml, requirements.md
+
+---
+
+## Output
+- Confirmation of deleted files
+- Confirmation that raw-idea.md was preserved
+- Fresh planning session started with original context
+- Follow `/plan` output format
+
+## IMPORTANT
+- **Always confirm before deleting.** Spec files may contain valuable design decisions.
+- **raw-idea.md is sacred.** It preserves the user's original intent and should never be deleted during re-plan.

--- a/.claude/commands/refactor.md
+++ b/.claude/commands/refactor.md
@@ -1,0 +1,205 @@
+---
+description: Start a refactor: create branch refactor/<slug>, create agent-os/specs/<date-slug>/spec.md. Local development only.
+---
+
+# /refactor
+
+Input: $ARGUMENTS
+
+## Format A (Preferred): YAML block
+```
+slug: extract-auth-service
+title: Extract authentication into service layer
+notes: |
+  Any extra context about the refactor.
+```
+
+## Format B: One-liner
+```
+extract-auth-service --title "Extract authentication into service layer" --notes "..."
+```
+
+---
+
+## Rules
+1. Branch name: `refactor/<slug>`
+2. Spec folder: `agent-os/specs/<YYYY-MM-DD>-<slug>/`
+3. No secrets, no `.env` reads
+4. Local commits only (no push)
+5. No behavior changes unless explicitly documented
+6. Ensure tests exist before refactoring
+
+---
+
+## Steps
+
+### Step 1: Parse $ARGUMENTS
+Extract:
+- slug (required, lowercase, hyphen-separated)
+- title (optional, derived from slug)
+- notes (optional)
+
+### Step 2: Ensure agent-os folders exist
+- `agent-os/specs/`
+
+### Step 3: Create branch
+```bash
+git checkout -b refactor/<slug>
+```
+
+### Step 4: Create Refactor Folder Structure
+Create `agent-os/specs/<YYYY-MM-DD>-<slug>/`:
+```
+agent-os/specs/<YYYY-MM-DD>-<slug>/
+├── planning/
+│   ├── raw-idea.md
+│   └── requirements.md
+├── orchestration.yml
+├── spec.md
+└── tasks.md
+```
+
+### Step 5: Create Raw Idea
+Create `agent-os/specs/<YYYY-MM-DD>-<slug>/planning/raw-idea.md`:
+
+```markdown
+# Raw Idea: <Title>
+
+**Type:** refactor
+**Slug:** <slug>
+**Created:** <YYYY-MM-DD>
+
+## Original Input
+
+```
+<Copy the entire $ARGUMENTS exactly as provided by user>
+```
+
+## Parsed Values
+
+- **Slug:** <slug>
+- **Title:** <title or derived from slug>
+- **Notes:** <notes if provided, or "none">
+```
+
+### Step 6: Create Refactor Requirements
+Create `agent-os/specs/<YYYY-MM-DD>-<slug>/planning/requirements.md`:
+
+```markdown
+# Refactor Requirements: <Title>
+
+## Motivation
+<!-- Why is this refactor needed? -->
+
+## Current State
+<!-- Current implementation and its issues -->
+
+## Target State
+<!-- Desired implementation after refactor -->
+
+## Constraints
+- No behavior changes unless explicitly documented
+- All existing tests must pass
+
+## Success Criteria
+- [ ] 
+- [ ] 
+
+## Notes
+<notes if provided>
+```
+
+### Step 7: Create Refactor Spec
+Create `agent-os/specs/<YYYY-MM-DD>-<slug>/spec.md`:
+
+```markdown
+# Specification: <Title>
+
+## Executive Summary
+<!-- Brief overview of the refactor -->
+
+---
+
+## Problem Statement
+
+**Current State:**
+- 
+
+**Desired State:**
+- 
+
+---
+
+## Goals & Success Criteria
+
+### Primary Goals
+1. 
+2. 
+
+### Non-Goals
+- 
+
+---
+
+## Current State Analysis
+- 
+
+---
+
+## Target State Design
+- Models:
+- Views:
+- Services:
+
+---
+
+## Files Affected
+- 
+
+---
+
+## Safety Net
+
+### Existing Tests
+<!-- Tests covering refactored code -->
+
+### Tests to Add
+- 
+
+---
+
+## Refactor Strategy
+1. 
+2. 
+3. 
+
+---
+
+## Testing Strategy
+- Unit:
+- Integration:
+- Regression:
+
+---
+
+## Rollback Plan
+<!-- How to revert if issues arise -->
+```
+
+### Step 8: Commit
+```bash
+git add agent-os/specs/<YYYY-MM-DD>-<slug>/
+git commit -m "chore(refactor): initialize <slug> spec"
+```
+
+## Output
+- Refactor slug:
+- Branch name:
+- Spec path: `agent-os/specs/<YYYY-MM-DD>-<slug>/spec.md`
+- Next: `/plan <slug>`
+
+## IMPORTANT
+**DO NOT automatically run `/plan`.** Always ask the user:
+> "Refactor initialized. Ready to run `/plan <slug>`?"
+
+Wait for explicit user confirmation before proceeding.

--- a/.claude/commands/resume-execute.md
+++ b/.claude/commands/resume-execute.md
@@ -1,0 +1,133 @@
+---
+description: Resume implementation from tasks.md. Picks up where you left off.
+---
+
+# /resume-execute
+
+Input: $ARGUMENTS
+
+## Format A (Preferred): YAML block
+```
+slug: user-export
+type: feature  # feature | bugfix | refactor (auto-detected from branch if omitted)
+notes: |
+  Session context or focus areas.
+```
+
+## Format B: One-liner
+```
+user-export --type feature --notes "focus on backend only"
+```
+
+---
+
+## Rules
+- Must be on correct branch (`feature/<slug>`, `bugfix/<slug>`, or `refactor/<slug>`)
+- Reads progress from `agent-os/specs/<YYYY-MM-DD>-<slug>/tasks.md`
+- Continues from last incomplete task
+- Local commits only (no push)
+
+## Type Detection
+If `type` not provided, detect from current branch:
+- `feature/<slug>` → feature
+- `bugfix/<slug>` → bugfix
+- `refactor/<slug>` → refactor
+
+### Finding Existing Specs
+To find an existing spec folder by slug:
+```bash
+ls agent-os/specs/ | grep <slug>
+```
+
+---
+
+## Steps
+
+### 1. Confirm branch
+Verify current branch matches `<type>/<slug>`
+
+### 2. Read tasks.md and orchestration.yml
+Read `agent-os/specs/<YYYY-MM-DD>-<slug>/tasks.md`:
+- Identify last completed task
+- Identify current/next incomplete task
+- Note any blockers or issues
+
+Read `agent-os/specs/<YYYY-MM-DD>-<slug>/orchestration.yml` (if exists):
+- Check task group assignments
+
+### 3. Read spec for context
+Read `agent-os/specs/<YYYY-MM-DD>-<slug>/spec.md`:
+- Review acceptance criteria
+- Check test plan
+
+### 4. Resume implementation
+
+```bash
+# Create/update models
+# Generate migrations
+docker compose exec be python manage.py makemigrations
+# Apply migrations
+docker compose exec be python manage.py migrate
+# Create views/APIs
+# Configure URLs
+# Add Celery tasks if needed
+```
+
+### 5. After each task completion
+
+```bash
+docker compose exec be python manage.py test apps.<app>
+docker compose logs be --tail=50
+```
+
+### 6. Update tasks.md
+After each task:
+- Mark task status: `[x]`
+- Add completion timestamp if needed
+- Note any issues or blockers
+
+### 7. Commit changes
+```bash
+git add <files>
+git commit -m "<prefix>(<slug>): <description>"
+```
+
+Use appropriate prefix:
+- `feat(<slug>):` for features
+- `fix(<slug>):` for bugfixes
+- `refactor(<slug>):` for refactors
+
+---
+
+## Output
+
+```
+## Resume Session Complete
+
+### Progress
+| Task | Before | After | Remaining |
+|------|--------|-------|-----------|
+| Total | X/Y | X/Y | Z tasks |
+
+### Tasks Completed This Session
+- [x] <task 1>
+- [x] <task 2>
+
+### Commits Made
+- <hash>: <message>
+- <hash>: <message>
+
+### Next Tasks
+- [ ] <next task 1>
+- [ ] <next task 2>
+
+### Blockers
+- (none or list)
+```
+
+---
+
+## Next Commands
+- `/run-tests <slug>` - Run tests
+- `/progress-status <slug>` - Check detailed progress
+- `/verify <slug>` - Run full verification

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -1,0 +1,84 @@
+# Code Review Command
+
+Perform comprehensive code review following project standards.
+
+## Review Focus
+
+1. **Architecture**: Adapter pattern compliance, Service layer, Clean architecture
+2. **Security**: Token encryption, webhook validation, OWASP Top 10
+3. **Code Quality**: PEP 8, SOLID, DRY/KISS/YAGNI
+4. **Django/DRF**: Models (UUIDs, indexes), Serializers, ViewSets, Celery
+5. **Performance**: DB optimization, N+1 queries, caching
+6. **Testing**: Coverage, mocking, AAA pattern
+
+## Process
+
+1. Read `CLAUDE.md` for project context
+2. Examine changed files thoroughly
+3. Check pattern adherence against codebase standards
+4. Verify security requirements (tokens, webhooks, input validation)
+5. Assess performance implications
+6. Review test coverage
+7. Provide specific file:line feedback with code examples
+
+## Output Format
+
+```markdown
+## Code Review Summary
+
+### ✅ Strengths
+- [Positive aspects]
+
+### ⚠️ Issues
+
+#### 🔴 Critical (Must Fix)
+- **file.py:123**: Issue → Fix
+
+#### 🟡 Important (Should Fix)
+- **file.py:456**: Issue → Solution
+
+#### 🔵 Suggestions
+- **file.py:789**: Current → Better
+
+### 📊 Metrics
+- Files: X | Security: X critical, X important
+- Pattern compliance: X% | Tests: [status]
+
+### ✅ Decision
+- [ ] Ready to merge
+- [ ] Approve with changes
+- [ ] Request changes
+```
+
+## Key Patterns to Check
+
+**Adapters**: ABC interface, required methods (authenticate, refresh_token, validate_webhook, handle_webhook, register_webhook), `@retry_with_backoff`, standardized responses
+
+**Security**: Token encryption (`TokenEncryption`), webhook signatures, OAuth state validation, input validation (model + serializer), no hardcoded secrets
+
+**Models**: UUID PKs, indexes, `clean()` + `save()`, timestamps, `help_text`
+
+**Services**: `@transaction.atomic`, error handling, logging, ErrorRecoveryManager
+
+**ViewSets**: Filter by user, `IsAuthenticated`, proper HTTP codes, `@action` for custom endpoints
+
+**Celery**: `@shared_task(bind, max_retries, delay)`, retry logic, logging
+
+## Critical Issues (Auto-fail)
+
+**Hardcoded Field Names** (CRITICAL): All dictionary keys and response field names MUST use centralized constants from `apps/common/constants/fields.py`. Hardcoded strings like `'success'`, `'results'`, `'digest_text'`, `'qr_code'` are NOT acceptable.
+
+```python
+# 🔴 CRITICAL - Hardcoded strings
+return {'success': True, 'message_count': count}
+obj.configuration.get('qr_code')
+
+# ✅ CORRECT - Use constants
+from apps.common.constants.fields import ResponseFields, ConfigFields
+return {ResponseFields.SUCCESS: True, ResponseFields.MESSAGE_COUNT: count}
+obj.configuration.get(ConfigFields.QR_CODE)
+```
+
+Available constant classes: `ResponseFields`, `AccountFields`, `MessageFields`, `ConversationFields`, `ConfigFields`, `DailySummaryFields`, `ProcessingStateFields`, `StatusValues`, `KBPayloadFields`, `EventPayloadFields`
+
+Be constructive and specific. Prioritize security and patterns over style.

--- a/.claude/commands/run-tests.md
+++ b/.claude/commands/run-tests.md
@@ -1,0 +1,139 @@
+---
+description: Run tests for this project. Supports Django. Mandatory after /execute.
+---
+
+# /run-tests
+
+Input: $ARGUMENTS
+
+## Format
+```
+<slug>
+```
+
+---
+
+## Rules
+- Read `agent-os/specs/<YYYY-MM-DD>-<slug>/spec.md` Test plan (if slug provided)
+- Update tasks.md with test results
+- All tests run inside Docker
+- **MANDATORY** - Must run after `/execute` completes
+
+### Finding Existing Specs
+To find an existing spec folder by slug:
+```bash
+ls agent-os/specs/ | grep <slug>
+```
+
+---
+
+## Steps
+
+### 1. Read Spec Test Plan (if slug provided)
+
+Check `agent-os/specs/<YYYY-MM-DD>-<slug>/spec.md` for:
+- Required test types
+- Specific test scenarios
+- Coverage requirements
+
+---
+
+### 2. Run Django Backend Tests
+
+```bash
+# All Django tests
+docker compose exec be python manage.py test
+
+# Specific app
+docker compose exec be python manage.py test apps.<app>
+
+# Specific test class
+docker compose exec be python manage.py test apps.<app>.tests.Test<Class>
+
+# Specific test method
+docker compose exec be python manage.py test apps.<app>.tests.Test<Class>.test_<method>
+
+# With coverage
+docker compose exec be pytest --cov=apps --cov-report=term-missing
+```
+
+**Test locations:**
+- Unit tests: `apps/<app>/tests/test_<module>.py`
+- Integration tests: `apps/<app>/tests/test_<feature>_integration.py`
+- E2E tests: `tests/e2e/`
+
+---
+
+### 3. Create Test Fixtures (if needed)
+
+```python
+# apps/<app>/fixtures/<slug>_data.json
+[
+  {
+    "model": "app.Model",
+    "pk": 1,
+    "fields": { ... }
+  }
+]
+```
+
+---
+
+### 4. Implement Missing Tests
+
+#### Django Unit Test Template
+```python
+from django.test import TestCase
+
+class <Feature>Tests(TestCase):
+    fixtures = ['<slug>_data.json']
+    
+    def test_<scenario>(self):
+        pass
+```
+
+---
+
+### 5. Run Full Test Suite
+
+```bash
+# Django
+docker compose exec be python manage.py test
+
+# E2E
+docker compose exec be pytest tests/e2e/ -v
+```
+
+---
+
+### 6. Update Spec and Tasks
+
+Update `agent-os/specs/<YYYY-MM-DD>-<slug>/tasks.md`:
+- Mark testing tasks complete
+- Record test counts and results
+
+Update `agent-os/specs/<YYYY-MM-DD>-<slug>/spec.md`:
+- Add test file paths to Testing Strategy section
+- Record coverage metrics if available
+
+---
+
+## Output
+
+```
+## Test Results
+
+### Django Backend
+- Tests run: X
+- Passed: X
+- Failed: X
+- Coverage: X%
+
+### Summary
+- Total: X tests
+- Status: ✓ All passing / ✗ X failures
+
+### Next Steps
+- /verify <slug> - Run full verification
+- /merge-to <target> - Merge to target branch (only if tests pass)
+```

--- a/.claude/commands/submit.md
+++ b/.claude/commands/submit.md
@@ -1,0 +1,102 @@
+---
+description: Final verification and commit. Mark feature as Done. Local only.
+---
+
+# /submit
+
+Input: $ARGUMENTS
+
+## Format
+```
+<slug>
+```
+
+---
+
+## Rules
+- All tests must pass
+- Spec must be complete (all success criteria met)
+- Local commit only (no push)
+
+### Finding Existing Specs
+To find an existing spec folder by slug:
+```bash
+ls agent-os/specs/ | grep <slug>
+```
+
+---
+
+## Steps
+
+### 1. Run full verification
+Run `/verify <slug>` or manually:
+
+```bash
+docker compose exec be python manage.py test
+docker compose exec be pytest tests/e2e/ -v
+```
+
+### 2. Check spec completeness
+- Read `agent-os/specs/<YYYY-MM-DD>-<slug>/spec.md`
+- All Success Criteria items marked complete
+- Test plan executed
+- All acceptance criteria met
+
+### 3. Check tasks.md completeness
+- Read `agent-os/specs/<YYYY-MM-DD>-<slug>/tasks.md`
+- All tasks marked `[x]`
+- All acceptance criteria in each task group met
+
+### 4. Final commit
+```bash
+git add .
+git commit -m "$(cat <<'EOF'
+feat(<slug>): complete implementation
+
+Changes:
+- <summary of changes>
+
+All tests passing
+E2E verified in Docker
+EOF
+)"
+```
+
+### 5. Update spec docs
+- Update `agent-os/specs/<YYYY-MM-DD>-<slug>/spec.md`:
+  - Add completion note at top if desired
+  - Ensure all Success Criteria checked
+- Update `agent-os/specs/<YYYY-MM-DD>-<slug>/tasks.md`:
+  - All tasks marked complete
+  - Add final summary if desired
+
+### 6. Cleanup (optional)
+```bash
+docker compose down
+```
+
+---
+
+## Output
+
+```
+## Submission Complete
+
+### Feature: <slug>
+- Status: Done
+- Branch: feature/<slug>
+- Commit: <hash>
+- Spec: agent-os/specs/<YYYY-MM-DD>-<slug>/
+
+### Tests
+| Check | Status |
+|-------|--------|
+| Unit tests | ✓ X/Y |
+| E2E tests | ✓ X/Y |
+
+### Summary
+<brief summary of changes>
+
+### Next Steps
+- /merge-to <target> - Merge to target branch
+```

--- a/.claude/commands/update-project-roadmap.md
+++ b/.claude/commands/update-project-roadmap.md
@@ -1,0 +1,229 @@
+---
+description: Update project roadmap based on current progress and scope changes for CadGenie. Reviews agent-os/product/roadmap.md against scope/ folder.
+---
+
+# /update-project-roadmap
+
+## Rules
+- Run periodically to keep roadmap in sync with progress
+- Compares current `agent-os/product/roadmap.md` with `scope/` docs
+- Updates phase completion status and adds new items from scope changes
+- Preserves existing structure while incorporating updates
+
+---
+
+## Steps
+
+### 1. Read Current State
+
+Read and analyze existing documents:
+
+**Roadmap:**
+- `agent-os/product/roadmap.md`
+
+**Scope Documents:**
+- `scope/prd.md`
+- `scope/scope.md`
+- `scope/mvp_checklist.md`
+- `scope/civil_boq_schema.md`
+- `scope/sld_bom_schema.md`
+- `scope/civil_pipeline_techstack.md`
+- `scope/sld_pipeline_techstack.md`
+- `scope/ui_user_flow.md`
+
+**Spec Progress:**
+- `agent-os/specs/*/tasks.md` (check completion status)
+
+---
+
+### 2. Analyze Progress
+
+For each roadmap item, check:
+- Is it marked complete `[x]` or pending `[ ]`?
+- Does corresponding code exist in `apps/`?
+- Is there a spec in `agent-os/specs/` for it?
+- What's the actual implementation status?
+
+Calculate phase completion:
+```
+Phase 1: X/Y items complete (Z%)
+Phase 2: X/Y items complete (Z%)
+...
+```
+
+---
+
+### 3. Detect Scope Changes
+
+Compare current scope docs against roadmap:
+
+**New Features:**
+- Items in `scope/` not yet in roadmap
+- New schemas or pipelines added
+- New user flow requirements
+
+**Modified Requirements:**
+- Changed accuracy targets
+- Updated output specifications
+- New constraints or exclusions
+
+**Removed/Deprecated:**
+- Items in roadmap no longer in scope
+- Features explicitly marked out of scope
+
+---
+
+### 4. Interview User (if needed)
+
+Ask brief questions only if scope changes detected:
+
+- "I found new items in scope/. Should I add them to the roadmap?"
+- "These items appear complete. Should I mark them done?"
+- "Priority changes detected. Update phase assignments?"
+
+---
+
+### 5. Update Roadmap
+
+Update `agent-os/product/roadmap.md` with:
+
+**Progress Updates:**
+- Mark completed items: `[ ]` → `[x]`
+- Add completion dates where applicable
+- Update phase progress percentages
+
+**New Items:**
+- Add items discovered in scope docs
+- Assign appropriate phase and priority
+- Link to relevant scope documents
+
+**Structure (preserve existing format):**
+
+```markdown
+# Product Roadmap
+
+## Phase 1: Foundation (apps/projects)
+
+- [x] Project model with estimation type (Civil BOQ / SLD BOM)
+- [x] Project status workflow: draft → awaiting_input → processing → ready/failed
+- [ ] Building type selection for Civil projects
+
+**Progress:** X/Y complete (Z%)
+
+---
+
+## Phase 2: Civil BOQ Pipeline (apps/civil)
+
+### Upload and Selection
+- [ ] PDF upload with validation (max 40 pages, vector PDFs only)
+...
+
+**Progress:** X/Y complete (Z%)
+
+---
+
+(continue for all phases)
+
+---
+
+## Summary
+
+| Phase | Items | Complete | Progress |
+|-------|-------|----------|----------|
+| Phase 1 | X | Y | Z% |
+| Phase 2 | X | Y | Z% |
+...
+
+## Recent Changes
+
+### YYYY-MM-DD
+- Added: <new items>
+- Completed: <finished items>
+- Modified: <changed items>
+```
+
+---
+
+### 6. Cross-Reference Specs
+
+Link active specs to roadmap items:
+- Check `agent-os/specs/*/spec.md` for related features
+- Note which specs cover which roadmap items
+- Identify roadmap items without specs (need `/feature-new`)
+
+---
+
+### 7. Identify Gaps
+
+Report items needing attention:
+
+**Missing Specs:**
+- Roadmap items without corresponding spec folders
+
+**Stale Items:**
+- Items marked in-progress but no recent activity
+
+**Blocking Dependencies:**
+- Items blocked by incomplete prerequisites
+
+---
+
+## Output
+
+```
+## Roadmap Updated
+
+### Progress Summary
+| Phase | Before | After | Delta |
+|-------|--------|-------|-------|
+| Phase 1 | X% | Y% | +Z% |
+| Phase 2 | X% | Y% | +Z% |
+...
+
+### Items Updated
+**Completed:**
+- [x] <item 1>
+- [x] <item 2>
+
+**Added (from scope/):**
+- [ ] <new item 1> — from prd.md
+- [ ] <new item 2> — from scope.md
+
+**Modified:**
+- <item>: <change description>
+
+### Scope Changes Detected
+| Document | Changes |
+|----------|---------|
+| prd.md | <summary> |
+| scope.md | <summary> |
+
+### Items Needing Attention
+**No spec created:**
+- <item 1>
+- <item 2>
+
+**Blocked:**
+- <item>: waiting on <dependency>
+
+### Next Steps
+- /feature-new <slug> - Create spec for new items
+- /plan <slug> - Plan implementation
+- /progress-status - Check detailed progress
+```
+
+---
+
+## Quick Update Mode
+
+For fast updates without interview:
+
+```
+/update-project-roadmap --quick
+```
+
+This will:
+1. Auto-mark items with completed specs as done
+2. Add all new scope items to appropriate phases
+3. Generate change summary
+4. Skip confirmation prompts

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -1,0 +1,130 @@
+---
+description: Run all quality checks and tests. Verify feature is complete.
+---
+
+# /verify
+
+Input: $ARGUMENTS
+
+## Format
+```
+<slug>
+```
+
+---
+
+## Rules
+- All checks run inside Docker
+- Must pass before marking feature complete
+- Update spec with results
+
+### Finding Existing Specs
+To find an existing spec folder by slug:
+```bash
+ls agent-os/specs/ | grep <slug>
+```
+
+---
+
+## Steps
+
+### 1. Start Docker Environment
+```bash
+docker compose up -d
+docker compose ps  # Verify all services running
+```
+
+---
+
+### 2. Django Backend Verification
+
+#### Migrations
+```bash
+docker compose exec be python manage.py migrate
+docker compose exec be python manage.py check
+docker compose exec be python manage.py showmigrations --list
+```
+
+#### Linting
+```bash
+docker compose exec be ruff check .
+docker compose exec be black --check .
+```
+
+#### Type Checking (if configured)
+```bash
+docker compose exec be mypy apps/
+```
+
+#### Unit Tests
+```bash
+docker compose exec be python manage.py test
+```
+
+#### Coverage
+```bash
+docker compose exec be pytest --cov=apps --cov-report=term-missing
+```
+
+---
+
+### 3. E2E Tests
+
+```bash
+# Django E2E
+docker compose exec be pytest tests/e2e/ -v
+```
+
+---
+
+### 4. Manual Verification
+
+- Check Docker logs: `docker compose logs be --tail=100`
+- Access API docs: http://localhost:8001/swagger/
+- Test key endpoints manually
+
+---
+
+### 5. Update Spec Docs
+
+Update `agent-os/specs/<YYYY-MM-DD>-<slug>/spec.md`:
+- Record verification results
+- Mark Success Criteria items as verified
+
+Update `agent-os/specs/<YYYY-MM-DD>-<slug>/tasks.md`:
+- Note verification status
+- Record any issues found
+
+---
+
+## Output
+
+```
+## Verification Results
+
+### Django Backend
+| Check | Status |
+|-------|--------|
+| Migrations | ✓ / ✗ |
+| Django check | ✓ / ✗ |
+| Linting | ✓ / ✗ |
+| Type check | ✓ / ✗ |
+| Unit tests | ✓ X/Y passed |
+| Coverage | X% |
+
+### E2E Tests
+| Test | Status |
+|------|--------|
+| <test_name> | ✓ / ✗ |
+
+### Summary
+- All checks: ✓ Passing / ✗ X failures
+- Feature status: Verified / Needs fixes
+
+### Issues Found
+- (none or list with severity)
+
+### Next Steps
+- /merge-to <target> - Merge to target branch (if verified)
+- /submit <slug> - Final submission
+```

--- a/.claude/hooks/run-tests-after-coding.sh
+++ b/.claude/hooks/run-tests-after-coding.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Claude Code Hook: Run tests after coding and flag broken tests
+# Triggered by the Stop hook when Claude finishes responding
+
+set -o pipefail
+
+cd "$CLAUDE_PROJECT_DIR" || exit 0
+
+# Parse the hook input to check if code was modified
+STDIN_DATA=$(cat)
+TRANSCRIPT=$(echo "$STDIN_DATA" | jq -r '.transcript // empty' 2>/dev/null)
+
+# Check if any Write or Edit tools were used in this response
+if echo "$TRANSCRIPT" | grep -qE '"tool":\s*"(Write|Edit)"'; then
+    CODE_MODIFIED=true
+else
+    CODE_MODIFIED=false
+fi
+
+# Only run tests if code was modified
+if [ "$CODE_MODIFIED" = false ]; then
+    exit 0
+fi
+
+echo "========================================" >&2
+echo "Running tests after code changes..." >&2
+echo "========================================" >&2
+
+# Run Django tests with failfast to stop on first failure
+TEST_OUTPUT=$(poetry run python manage.py test --failfast 2>&1)
+TEST_EXIT_CODE=$?
+
+if [ $TEST_EXIT_CODE -eq 0 ]; then
+    echo "" >&2
+    echo "All tests passed!" >&2
+    echo "========================================" >&2
+    exit 0
+else
+    echo "" >&2
+    echo "TESTS FAILED!" >&2
+    echo "========================================" >&2
+    echo "" >&2
+
+    # Extract and display failure information
+    echo "$TEST_OUTPUT" | tail -50 >&2
+
+    echo "" >&2
+    echo "========================================" >&2
+    echo "Please fix the failing tests above." >&2
+    echo "========================================" >&2
+
+    # Exit with code 2 to block and show error to Claude
+    exit 2
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,18 @@
+{
+  "permissions": {
+    "allow": [
+      "WebFetch(domain:dsebd.org)",
+      "Bash(python -c \"import sys; print\\(sys.executable\\)\")",
+      "Bash(pip install *)",
+      "Bash(python -c ' *)",
+      "WebFetch(domain:www.dsebd.org)",
+      "Bash(echo \"compile done \\(rc=$?\\)\")",
+      "Bash(rm -rf e:/tmp/e2e)",
+      "Bash(mkdir -p e:/tmp/e2e)",
+      "Bash(git checkout *)",
+      "Bash(git commit -q -m ' *)",
+      "Bash(git push *)",
+      "Bash(gh pr create --base master --head feature/news-blocktrade-scrapers --title 'Add company identity/links, news and block-trade scraping' --body ' *)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@
 
 
 
+# Claude Code local/personal settings (machine-specific, not shared)
+.claude/settings.local.json
+
 venv/
 env/
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -12,6 +12,22 @@ this easy-to-use wrapper for mplfinance.
 pip install stocksurferbd
 
 ```
+## Configuration (TLS / session / timeout)
+
+All loaders (`PriceData`, `FundamentalData`, `BlockTradeData`) accept optional
+arguments to control the underlying HTTP request:
+
+```python
+from stocksurferbd import PriceData
+
+# DSE's certificate chain is incomplete in some environments; disable TLS
+# verification, reuse a session, or set a custom timeout if needed.
+loader = PriceData(verify=False, session=None, timeout=60)
+```
+
+Defaults (`verify=True`, a fresh `requests.Session`, 30s timeout) preserve the
+previous behaviour.
+
 ## Usage
 
 #### Downloading historical price data of a single stock-
@@ -74,13 +90,56 @@ There are 2 parameters `save_company_data()` this method-
 1. ```symbol``` : Provide stock symbol of the company as string.
 2. ```path``` : Provide the name of the directory as string to save the company data. 
 
+The `ACI_company_data.xlsx` file also includes company identity and disclosure
+columns: `company_name`, `website`, `address`, `financial_statement_link` and
+`price_sensitive_info_link`.
+
+#### Downloading company news / disclosures (last 2 years) from DSE-
+
+```python
+from stocksurferbd import FundamentalData
+loader = FundamentalData()
+
+loader.save_news_data('ACI', path='company_info', years=2)
+```
+The above code creates `ACI_news_data.xlsx` in the `company_info` folder with
+columns `symbol`, `date`, `title` and `news`, sorted newest first.
+
+Parameters of `save_news_data()`-
+
+1. ```symbol``` : Provide stock symbol of the company as string.
+2. ```path``` : Provide the directory as string to save the news data.
+3. ```years``` : Rolling time window in years (default `2`). Pass `years=None`
+   to download all available news.
+
+#### Downloading block trade data from DSE-
+
+```python
+from stocksurferbd import BlockTradeData
+loader = BlockTradeData()
+
+# Current day's block transactions for all listed symbols
+loader.save_block_trade_data(file_name='block_trade_data.xlsx', market='DSE')
+
+# Block-market related disclosures for one company over the last 2 years
+loader.save_block_trade_news_data('ACI', path='company_info', years=2)
+```
+DSE does not publish a historical block-trade archive, so
+`save_block_trade_data()` stores the **current day's** actual block transactions
+(`DATE`, `TRADING_CODE`, `MAX_PRICE`, `MIN_PRICE`, `TRADES`, `QUANTITY`,
+`VALUE_MN`) — run it daily to build history. `save_block_trade_news_data()`
+provides a historical per-company proxy from block-market related news.
+
+Both methods also have `get_block_trades_df()` and `get_block_trade_news_df()`
+variants that return a `pandas` DataFrame instead of writing a file.
+
 #### Create Candlestick charts for analyzing price history-
 
 ```python
 
 from stocksurferbd import CandlestickPlot
 
-cd_plot = CandlestickPlot(csv_path='ACI_history.xlsx', symbol='ACI')
+cd_plot = CandlestickPlot(file_path='ACI_history.xlsx', symbol='ACI')
 cd_plot.show_plot(
     data_n=120,
     resample=True,
@@ -93,7 +152,7 @@ Stock broker trading panels.
 
 <br/>There are 2 parameters ```__init__()``` method of CandlestickPlot class-
 
-1. ```csv_path``` : Provide the path of history csv file as string to generate plot
+1. ```file_path``` : Provide the path of history file as string to generate plot
 2. ```symbol``` : Provide stock symbol of the company as string.
 
 <br/>There are also 3 parameters show_plot() method-
@@ -112,6 +171,65 @@ The following are some example images of Candlestick plots-
 <br><br>![Candlestick Plot 3days](https://github.com/skfarhad/stocksurferbd/blob/master/price_plot_3d.png?raw=true)
 
 
+
+## Output data schema
+
+Each method writes an `.xlsx` file (and the `get_*_df` variants return the same
+data as a `pandas` DataFrame). The columns of each output are listed below.
+
+#### Price history — `PriceData.save_history_data`
+| Market | Columns |
+|--------|---------|
+| DSE | `DATE`, `TRADING_CODE`, `LTP`, `HIGH`, `LOW`, `OPENP`, `CLOSEP`, `YCP`, `TRADE`, `VALUE_MN`, `VOLUME` |
+| CSE | `DATE`, `TRADING_CODE`, `LTP`, `OPENP`, `HIGH`, `LOW`, `CLOSEP`, `YCP`, `% CHANGE`, `TRADE`, `VALUE_MN`, `VOLUME` |
+
+#### Current prices — `PriceData.save_current_data`
+| Market | Columns |
+|--------|---------|
+| DSE | `DATE`, `TRADING_CODE`, `LTP`, `HIGH`, `LOW`, `CLOSEP`, `YCP`, `% CHANGE`, `TRADE`, `VALUE_MN`, `VOLUME` |
+| CSE | `DATE`, `TRADING_CODE`, `LTP`, `OPEN`, `HIGH`, `LOW`, `YCP`, `TRADE`, `VALUE_MN`, `VOLUME` |
+
+> Note: the price files are written with the DataFrame index, so they also
+> contain a leading unnamed index column.
+
+#### Company data — `FundamentalData.save_company_data` → `<symbol>_company_data.xlsx`
+One row per company. Columns, grouped:
+
+- **Identity / links** *(new in 1.0.0)*: `company_name`, `website`, `address`,
+  `financial_statement_link`, `price_sensitive_info_link`
+- **Basic**: `symbol`, `auth_capital`, `trade_start`, `paid_up_capital`,
+  `instrument_type`, `face_value`, `market_lot`, `ltp`, `last_agm_date`,
+  `market_cap`, `outstanding_share`, `sector`, `listing_year`, `market_category`
+- **Dividend / reserves**: `right_issue`, `year_end`, `reserve_w_oci`,
+  `others_oci`, `cash_dividend_p`, `cash_dividend_year`, `stock_dividend_p`,
+  `stock_dividend_year`
+- **Shareholding %**: `sh_director`, `sh_govt`, `sh_inst`, `sh_foreign`,
+  `sh_public`
+- **Interim EPS** (`_q1`, `_q2`, `_hy`, `_q3`, `_9m`, `_yr` suffixes):
+  `eps_basic_*`, `eps_diluted_*`, `eps_cop_basic_*`, `eps_cop_diluted_*`
+
+> The identity/links columns are appended at the end, so existing column
+> positions are unchanged (backward compatible).
+
+#### Financial data — `FundamentalData.save_company_data` → `<symbol>_financial_data.xlsx`
+One row per financial year:
+`symbol`, `year`, `eps_original`, `eps_restated`, `eps_diluted`,
+`eps_cop_original`, `eps_cop_restated`, `eps_cop_diluted`, `nav_original`,
+`nav_restated`, `nav_diluted`, `pco`, `profit`, `tci`, `pe_original`,
+`pe_restated`, `pe_diluted`, `pe_cop_original`, `pe_cop_restated`,
+`pe_cop_diluted`, `dividend_p`, `dividend_yield_p`
+
+#### Company news — `FundamentalData.save_news_data` → `<symbol>_news_data.xlsx` *(new in 1.0.0)*
+One row per news item, newest first:
+`symbol`, `date`, `title`, `news`
+
+#### Block trades (current day) — `BlockTradeData.save_block_trade_data` *(new in 1.0.0)*
+One row per block transaction for the latest trading day:
+`DATE`, `TRADING_CODE`, `MAX_PRICE`, `MIN_PRICE`, `TRADES`, `QUANTITY`, `VALUE_MN`
+
+#### Block-trade news proxy — `BlockTradeData.save_block_trade_news_data` → `<symbol>_block_trade_news.xlsx` *(new in 1.0.0)*
+Block-market related disclosures (a filtered view of the news feed):
+`symbol`, `date`, `title`, `news`
 
 ## If you want to contribute
 

--- a/agent-os/config.yml
+++ b/agent-os/config.yml
@@ -1,0 +1,10 @@
+version: 3.0
+last_compiled: 2026-06-17
+
+# ================================================
+# stocksurferbd - Agent OS Configuration
+# ================================================
+profile: default
+product_name: stocksurferbd
+product_type: python-library
+description: Python library for downloading price history and fundamental data of Dhaka (DSE) and Chittagong (CSE) Stock Exchange companies, plus a candlestick plotting wrapper over mplfinance.

--- a/agent-os/product/mission.md
+++ b/agent-os/product/mission.md
@@ -1,0 +1,38 @@
+# Product Mission
+
+**`stocksurferbd` — an open-source Python library for downloading Dhaka (DSE) and Chittagong (CSE) stock market data and plotting it. Published on [PyPI](https://pypi.org/project/stocksurferbd/).**
+
+## Vision
+Be the simplest, most reliable way for Bangladeshi investors, analysts, and developers to get DSE/CSE market data into Python — so anyone can build their own analysis without scraping the exchange websites by hand.
+
+## Mission
+The library wraps the public DSE and CSE websites behind a small, stable Python API. It turns the exchanges' HTML tables into clean `pandas` data and Excel files, and provides an easy candlestick charting helper on top of `mplfinance`. It is a **data-access and plotting toolkit**, not an analysis, scoring, or trading product — those are left to the user who consumes the data.
+
+## Values
+- **Small and focused** — three public classes (`PriceData`, `FundamentalData`, `CandlestickPlot`), no framework, no database, no server.
+- **Public data only** — scrapes the same pages a browser would; respects the source sites.
+- **Boring and dependable** — pinned dependencies, predictable Excel/`DataFrame` output, easy to install with one `pip install`.
+- **Easy to start** — every feature is a few lines of code, documented with copy-paste examples in the README.
+
+## Target Users
+- **Retail and individual investors** in Bangladesh who want their own data instead of broker panels.
+- **Analysts and researchers** building fundamental/technical studies of DSE/CSE listings.
+- **Python developers** who need DSE/CSE price and fundamentals as a building block in a larger app or notebook.
+
+## What the library does today
+- **Price history** — daily OHLCV history for a single symbol (DSE day-end archive; CSE 6-month graph data).
+- **Current/live prices** — one snapshot of all listed symbols for DSE or CSE.
+- **Fundamentals** — per-company fundamentals and year-wise financial performance from the DSE company page (capital, face value, market lot, dividend history, shareholding %, EPS/NAV/PE).
+- **Charting** — candlestick plots (optionally resampled to multi-day steps) via a thin wrapper over `mplfinance`.
+- **Output** — everything saved as `.xlsx` via `pandas` + `openpyxl`; charts rendered with `matplotlib`.
+
+## What it is not
+- Not a trading bot, signal generator, or scoring engine.
+- Not a hosted service or API — it is an importable library run locally.
+- Not a guaranteed feed — it depends on the layout of the public DSE/CSE pages and breaks if those change.
+
+## Success Metrics
+- **Reliability** — fetchers keep working against the live DSE/CSE pages; breakage is caught and fixed quickly.
+- **Coverage** — breadth of data fields exposed (price, fundamentals, and planned additions like company name/website/news/block trades).
+- **Ease of use** — minimal lines of code per task; clear errors when a symbol or source is unavailable.
+- **Adoption** — PyPI installs and GitHub usage.

--- a/agent-os/product/roadmap.md
+++ b/agent-os/product/roadmap.md
@@ -1,0 +1,58 @@
+# Product Roadmap
+
+**`stocksurferbd` is a published library (PyPI `0.1.3`). Core price, fundamentals, and candlestick plotting work today. The roadmap below widens data coverage and hardens the library.**
+
+The library scrapes the public DSE/CSE websites, normalises the tables with `pandas`, and writes `.xlsx` files; it also plots candlesticks via `mplfinance`. Roadmap items are sequenced to broaden the data we expose before investing in packaging/quality polish.
+
+---
+
+## Shipped
+
+1. [x] **Price history (DSE & CSE)** — `PriceData.save_history_data` — daily OHLCV for one symbol from the DSE day-end archive and the CSE 6-month graph data.
+2. [x] **Current/live prices (DSE & CSE)** — `PriceData.save_current_data` — one snapshot of all listed symbols.
+3. [x] **Company fundamentals (DSE)** — `FundamentalData.save_company_data` — basic info, dividend history, shareholding %, market category/sector, and interim EPS, written to `<symbol>_company_data.xlsx`.
+4. [x] **Year-wise financial performance (DSE)** — EPS/NAV/PE/dividend history, written to `<symbol>_financial_data.xlsx`.
+5. [x] **Candlestick plotting** — `CandlestickPlot.show_plot` — `mplfinance` wrapper with optional multi-day resampling.
+6. [x] **Excel output** — all fetchers persist to `.xlsx` via `pandas` + `openpyxl`.
+
+## Phase 1: Wider fundamental coverage
+
+**Theme: capture the company-page fields we currently skip.**
+
+7. [ ] **Company identity** — full company name, website URL, and registered address from the DSE company page (currently not captured).
+8. [ ] **Price-sensitive information / news** — the disclosure/PSI links on the company page.
+9. [ ] **Block / spot trades** — block-transaction data (open decision: confirm DSE exposes a scrapeable source).
+10. [ ] **Circuit breaker bands** — per-symbol upper/lower circuit limits (the `cbul.php` source is already referenced but commented out).
+11. [ ] **CSE fundamentals** — extend `FundamentalData` beyond DSE (currently DSE-only).
+
+## Phase 2: Robustness & data quality
+
+12. [ ] **Resilient parsing** — replace positional table indexing with header-aware lookups so layout changes degrade gracefully.
+13. [ ] **Clear errors & retries** — typed exceptions per source, request timeouts, and retry/backoff on transient failures.
+14. [ ] **Output options** — return `DataFrame` directly (not only `.xlsx`), and offer CSV/Parquet as alternatives.
+15. [ ] **Configurable HTTP** — user-agent, timeout, and TLS-verification options on a session.
+
+## Phase 3: Packaging & developer experience
+
+16. [ ] **Test suite** — unit tests against saved HTML fixtures so parsing is verified without hitting the live sites.
+17. [ ] **Type hints + linting** — full type annotations, `flake8`/`black` config, optional `mypy`.
+18. [ ] **CI & release** — GitHub Actions for lint/test and automated PyPI publish (`build` + `twine`).
+19. [ ] **Docs** — expand README/usage and add API reference for the three public classes.
+
+---
+
+## Prioritization
+
+### Now (Phase 1)
+The biggest gap is fundamental coverage — the DSE company page exposes company name, website, address, and PSI/news links that we parse past today. Capturing these is high value and low risk.
+
+### Next (Phase 2)
+Make the existing scrapers durable: header-aware parsing and proper error handling so a DSE/CSE layout tweak doesn't silently corrupt output.
+
+### Later (Phase 3)
+Tests, typing, and CI keep the library trustworthy as coverage grows.
+
+## Open Decisions
+- Whether DSE/CSE expose a stable, scrapeable source for block/spot trades and circuit-band data (gates Phase 1 §9–10).
+- Whether to keep `.xlsx` as the default output or move to returning `DataFrame`s with optional file export (Phase 2 §14).
+- How much CSE parity to commit to, given CSE's different page structure.

--- a/agent-os/product/tech-stack.md
+++ b/agent-os/product/tech-stack.md
@@ -1,0 +1,71 @@
+# Tech Stack
+
+> `stocksurferbd` is a small, dependency-light Python library. No web framework, database, or services — it scrapes the public DSE/CSE sites, normalises the data with `pandas`, writes `.xlsx`, and plots candlesticks with `mplfinance`. Versions are pinned in `requirements.txt` and `stocksurferbd_pkg/setup.py`.
+
+## Runtime
+
+| Component | Technology | Purpose |
+|-----------|------------|---------|
+| Language | Python 3.10+ | Core language (`python_requires=">=3.10"`) |
+| HTTP | requests 2.32.3 | Fetching DSE/CSE pages |
+| HTML parsing | beautifulsoup4 4.9.3 | Extracting tables from page HTML |
+| Data | pandas 2.2.2 | Tabular normalisation and Excel I/O |
+| Excel | openpyxl 3.1.5 | `.xlsx` writing engine for pandas |
+| Dates | python-dateutil | Parsing dates from page text |
+| Charts | matplotlib 3.9.2 | Rendering backend |
+| Candlesticks | mplfinance 0.12.x | Candlestick/volume plotting wrapper |
+| Indicators | pyti 0.2.2, tapy 1.9.1 | Technical-indicator overlays for plots |
+
+## Package layout
+
+| Path | Purpose |
+|------|---------|
+| `stocksurferbd_pkg/stocksurferbd/` | The importable package |
+| `price_data_scraper.py` → `PriceData` | Price history + current/live prices (DSE/CSE) |
+| `fundamental_data_scraper.py` → `FundamentalData` | Company + financial fundamentals (DSE) |
+| `price_plots.py` → `CandlestickPlot` | mplfinance candlestick wrapper |
+| `stocksurferbd_pkg/setup.py` | Packaging metadata (name, version, deps) |
+| `fetch_*.py`, `plot_price_data.py` (repo root) | Example/driver scripts |
+
+## Public API
+
+| Class | Key methods |
+|-------|-------------|
+| `PriceData` | `save_history_data(symbol, file_name, market)`, `save_current_data(file_name, market)` |
+| `FundamentalData` | `save_company_data(symbol, path)` |
+| `CandlestickPlot` | `__init__(csv_path, symbol)`, `show_plot(data_n, resample, step)` |
+
+## Data sources (public DSE/CSE pages)
+
+| Source | URL pattern |
+|--------|-------------|
+| DSE day-end archive (history) | `dsebd.org/day_end_archive.php` |
+| DSE live prices | `dsebd.org/latest_share_price_scroll_l.php` |
+| DSE company fundamentals | `dsebd.org/displayCompany.php?name=<symbol>` |
+| DSE circuit breaker (planned) | `dsebd.org/cbul.php` |
+| CSE history | `cse.com.bd/company/company_graph_6m/` |
+| CSE current price | `cse.com.bd/market/current_price` |
+
+## Output
+
+- **Excel** — `.xlsx` files written via `pandas.DataFrame.to_excel` (openpyxl engine).
+- **Charts** — `matplotlib`/`mplfinance` figures shown interactively.
+
+## Build & publish
+
+| Tool | Purpose |
+|------|---------|
+| wheel | Building the distribution |
+| twine | Uploading to PyPI |
+| setuptools | `setup.py sdist bdist_wheel` |
+
+```
+python setup.py sdist bdist_wheel
+twine upload dist/*
+```
+
+## Distribution
+
+- **PyPI**: [`stocksurferbd`](https://pypi.org/project/stocksurferbd/)
+- **Source**: https://github.com/skfarhad/stocksurferbd
+- **License**: MIT

--- a/agent-os/specs/YYYY-MM-DD-feature-slug/orchestration.yml
+++ b/agent-os/specs/YYYY-MM-DD-feature-slug/orchestration.yml
@@ -1,0 +1,53 @@
+# Orchestration Configuration
+# This file defines the workflow for implementing this feature
+
+version: 1.0
+
+metadata:
+  slug: feature-slug
+  type: feature  # feature | bugfix | refactor
+  created: YYYY-MM-DD
+  branch: feature/feature-slug
+
+# Dependencies between task groups
+dependencies:
+  - group: setup-models
+    depends_on: []
+  - group: api-development
+    depends_on: [setup-models]
+  - group: frontend
+    depends_on: [api-development]
+  - group: testing
+    depends_on: [api-development, frontend]
+  - group: documentation
+    depends_on: [testing]
+
+# Verification steps after each group
+verification:
+  setup-models:
+    - command: docker compose exec be python manage.py check
+    - command: docker compose exec be python manage.py migrate --check
+  api-development:
+    - command: docker compose exec be pytest apps/<app>/tests/ -v
+  frontend:
+    - manual: Check UI in browser at http://localhost:8001/
+  testing:
+    - command: docker compose exec be pytest --cov=apps --cov-report=term-missing
+  documentation:
+    - manual: Review API docs at http://localhost:8001/swagger/
+
+# Rollback commands if something fails
+rollback:
+  setup-models:
+    - command: docker compose exec be python manage.py migrate <app> <previous_migration>
+  api-development:
+    - command: git checkout -- apps/<app>/
+  frontend:
+    - command: git checkout -- apps/webui/
+
+# Completion criteria
+completion:
+  - All tasks marked ✅ Complete
+  - All tests passing
+  - Code reviewed
+  - Merged to target branch

--- a/agent-os/specs/YYYY-MM-DD-feature-slug/planning/raw-idea.md
+++ b/agent-os/specs/YYYY-MM-DD-feature-slug/planning/raw-idea.md
@@ -1,0 +1,24 @@
+# Raw Idea
+
+## Source
+<!-- Where did this idea come from? User request, bug report, internal discussion, etc. -->
+[TODO: Source of the idea]
+
+## Initial Description
+<!-- Raw, unprocessed description of what's needed -->
+[TODO: Describe the feature/fix in plain language]
+
+## Context
+<!-- Any relevant background information -->
+- Current state: [describe current behavior]
+- Problem: [what's wrong or missing]
+- Impact: [who is affected and how]
+
+## Initial Thoughts
+<!-- Quick notes on possible approaches -->
+- [Approach 1]
+- [Approach 2]
+
+## Questions to Clarify
+- [ ] [Question 1]
+- [ ] [Question 2]

--- a/agent-os/specs/YYYY-MM-DD-feature-slug/planning/requirements.md
+++ b/agent-os/specs/YYYY-MM-DD-feature-slug/planning/requirements.md
@@ -1,0 +1,37 @@
+# Requirements
+
+## Functional Requirements
+
+### FR-1: [Requirement Name]
+- **Description**: [What the system should do]
+- **Acceptance Criteria**:
+  - [ ] [Criterion 1]
+  - [ ] [Criterion 2]
+- **Priority**: High | Medium | Low
+
+### FR-2: [Requirement Name]
+- **Description**: [What the system should do]
+- **Acceptance Criteria**:
+  - [ ] [Criterion 1]
+  - [ ] [Criterion 2]
+- **Priority**: High | Medium | Low
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+- [Requirement description]
+
+### NFR-2: Security
+- [Requirement description]
+
+## Constraints
+- [Constraint 1]
+- [Constraint 2]
+
+## Dependencies
+- [Dependency 1]
+- [Dependency 2]
+
+## Out of Scope
+- [Item 1]
+- [Item 2]

--- a/agent-os/specs/YYYY-MM-DD-feature-slug/spec.md
+++ b/agent-os/specs/YYYY-MM-DD-feature-slug/spec.md
@@ -1,0 +1,155 @@
+# Feature Specification: [Feature Name]
+
+## Overview
+
+### Objective
+<!-- One sentence describing what this feature accomplishes -->
+[TODO: Describe the objective]
+
+### Background
+<!-- Why is this needed? Link to raw-idea.md if applicable -->
+[TODO: Provide background context]
+
+### Scope
+- **In Scope**: [List what's included]
+- **Out of Scope**: [List what's explicitly excluded]
+
+---
+
+## User Stories
+
+| ID | As a... | I want to... | So that... |
+|----|---------|--------------|------------|
+| US-1 | [User type] | [Action] | [Benefit] |
+| US-2 | [User type] | [Action] | [Benefit] |
+
+---
+
+## Technical Design
+
+### Architecture Overview
+<!-- High-level architecture description -->
+```
+[Diagram or description of component interactions]
+```
+
+### Data Model Changes
+
+#### New Models
+```python
+# apps/<app>/models.py
+
+class NewModel(models.Model):
+    """Description of the model."""
+    field_name = models.CharField(max_length=100)
+    created_at = models.DateTimeField(auto_now_add=True)
+    
+    class Meta:
+        db_table = 'app_newmodel'
+```
+
+#### Model Modifications
+- `ExistingModel`: Add `new_field` (CharField, max_length=50, nullable)
+
+### API Endpoints
+
+#### `POST /api/v0/<resource>/`
+- **Description**: [What this endpoint does]
+- **Auth**: JWT required
+- **Request Body**:
+```json
+{
+  "field1": "string",
+  "field2": 123
+}
+```
+- **Response** (201):
+```json
+{
+  "id": 1,
+  "field1": "string",
+  "field2": 123,
+  "created_at": "2024-01-01T00:00:00Z"
+}
+```
+- **Errors**: 400 (validation), 401 (unauthorized), 500 (server error)
+
+#### `GET /api/v0/<resource>/{id}/`
+- **Description**: [What this endpoint does]
+- **Auth**: JWT required
+- **Response** (200):
+```json
+{
+  "id": 1,
+  "field1": "string",
+  "field2": 123
+}
+```
+
+### Frontend Changes
+
+#### New Components
+- `ComponentName.js` - [Description]
+
+#### Modified Components
+- `ExistingComponent.js` - [What changes]
+
+---
+
+## Acceptance Criteria
+
+### Functional
+- [ ] AC-1: [Specific testable criterion]
+- [ ] AC-2: [Specific testable criterion]
+- [ ] AC-3: [Specific testable criterion]
+
+### Non-Functional
+- [ ] AC-4: API response time < 500ms
+- [ ] AC-5: Test coverage > 80%
+
+---
+
+## Test Plan
+
+### Unit Tests
+| Test | Description | Location |
+|------|-------------|----------|
+| `test_<name>` | [What it tests] | `apps/<app>/tests/test_<file>.py` |
+
+### Integration Tests
+| Test | Description |
+|------|-------------|
+| [Test name] | [What it tests] |
+
+### Manual Testing Checklist
+- [ ] [Test scenario 1]
+- [ ] [Test scenario 2]
+
+---
+
+## Migration Plan
+
+### Database Migrations
+1. `python manage.py makemigrations <app>`
+2. `python manage.py migrate`
+
+### Data Migration (if needed)
+- [Description of data migration steps]
+
+### Rollback Plan
+- [How to rollback if issues occur]
+
+---
+
+## Risks & Mitigations
+
+| Risk | Impact | Probability | Mitigation |
+|------|--------|-------------|------------|
+| [Risk 1] | High/Med/Low | High/Med/Low | [Mitigation strategy] |
+
+---
+
+## References
+- [Link to related docs]
+- [Link to design mockups]
+- [Link to external resources]

--- a/agent-os/specs/YYYY-MM-DD-feature-slug/tasks.md
+++ b/agent-os/specs/YYYY-MM-DD-feature-slug/tasks.md
@@ -1,0 +1,79 @@
+# Tasks: [Feature Name]
+
+## Task Groups
+
+### Group 1: Setup & Models
+| ID | Task | Status | Commit |
+|----|------|--------|--------|
+| T1.1 | Create new model(s) | ⬜ Pending | - |
+| T1.2 | Generate migrations | ⬜ Pending | - |
+| T1.3 | Apply migrations | ⬜ Pending | - |
+
+### Group 2: API Development
+| ID | Task | Status | Commit |
+|----|------|--------|--------|
+| T2.1 | Create serializers | ⬜ Pending | - |
+| T2.2 | Create viewsets/views | ⬜ Pending | - |
+| T2.3 | Add URL routes | ⬜ Pending | - |
+| T2.4 | Add API documentation | ⬜ Pending | - |
+
+### Group 3: Frontend
+| ID | Task | Status | Commit |
+|----|------|--------|--------|
+| T3.1 | Create UI components | ⬜ Pending | - |
+| T3.2 | Add JavaScript logic | ⬜ Pending | - |
+| T3.3 | Style components | ⬜ Pending | - |
+
+### Group 4: Testing
+| ID | Task | Status | Commit |
+|----|------|--------|--------|
+| T4.1 | Write unit tests | ⬜ Pending | - |
+| T4.2 | Write integration tests | ⬜ Pending | - |
+| T4.3 | Manual testing | ⬜ Pending | - |
+
+### Group 5: Documentation & Cleanup
+| ID | Task | Status | Commit |
+|----|------|--------|--------|
+| T5.1 | Update API docs | ⬜ Pending | - |
+| T5.2 | Code cleanup | ⬜ Pending | - |
+
+---
+
+## Progress Summary
+
+| Group | Total | Done | Remaining |
+|-------|-------|------|-----------|
+| Setup & Models | 3 | 0 | 3 |
+| API Development | 4 | 0 | 4 |
+| Frontend | 3 | 0 | 3 |
+| Testing | 3 | 0 | 3 |
+| Documentation | 2 | 0 | 2 |
+| **Total** | **15** | **0** | **15** |
+
+---
+
+## Status Legend
+- ⬜ Pending
+- 🔄 In Progress
+- ✅ Complete
+- ❌ Blocked
+- ⏭️ Skipped
+
+---
+
+## Session Notes
+
+### Session 1 - [DATE]
+- Started: [Time]
+- Ended: [Time]
+- Notes:
+  - [What was accomplished]
+  - [Blockers encountered]
+  - [Next steps]
+
+---
+
+## Blockers
+| ID | Blocker | Blocking Tasks | Status |
+|----|---------|----------------|--------|
+| B1 | [Description] | T1.1, T1.2 | ⬜ Open |

--- a/agent-os/standards/global/coding-style.md
+++ b/agent-os/standards/global/coding-style.md
@@ -1,0 +1,15 @@
+## Coding style best practices
+
+- **Consistent Naming Conventions**: Establish and follow naming conventions for variables, functions, classes, and files across the codebase.
+- **Automated Formatting**: Maintain consistent code style (indentation, line breaks, etc.); `black` is the intended formatter.
+- **Meaningful Names**: Choose descriptive names that reveal intent; avoid abbreviations and single-letter variables except in narrow contexts.
+- **Small, Focused Functions**: Keep functions small and focused on a single task for better readability and testability.
+- **Consistent Indentation**: Use 4-space indentation (PEP 8) and configure your editor/linter to enforce it.
+- **Remove Dead Code**: Delete unused code, commented-out blocks, and imports rather than leaving them as clutter. Several scrapers carry commented-out debug `print`s and dead branches — prefer removing them.
+- **Backward compatibility only when required**: Unless specifically instructed otherwise, assume you do not need to write extra code to preserve backward compatibility.
+- **DRY Principle**: Avoid duplication by extracting common logic into reusable functions. For example, the `parse_float` / `parse_int` helpers are duplicated across `PriceData` and `FundamentalData` — shared parsing helpers should live in one place.
+
+## Constants over magic strings
+
+- Source URLs, table CSS classes, and column names are repeated string literals. Keep them as named class-level constants (as `PriceData` already does for its URLs) rather than inline literals, so a site change is a one-line edit.
+- Market codes (`'DSE'`, `'CSE'`) and other small closed sets should be defined once and referenced, not retyped at each call site.

--- a/agent-os/standards/global/commenting.md
+++ b/agent-os/standards/global/commenting.md
@@ -1,0 +1,5 @@
+## Code commenting best practices
+
+- **Self-Documenting Code**: Write code that explains itself through clear structure and naming
+- **Minimal, helpful comments**: Add concise, minimal comments to explain large sections of code logic.
+- **Don't comment changes or fixes**: Do not leave code comments that speak to recent or temporary changes or fixes. Comments should be evergreen informational texts that are relevant far into the future.

--- a/agent-os/standards/global/conventions.md
+++ b/agent-os/standards/global/conventions.md
@@ -1,0 +1,10 @@
+## General development conventions
+
+- **Consistent Project Structure**: Keep the importable package under `stocksurferbd_pkg/stocksurferbd/`; keep example/driver scripts (`fetch_*.py`, `plot_*.py`) at the repo root. New public classes are exported from the package `__init__.py`.
+- **Clear Documentation**: Keep `README.md` up to date — it is both the user guide and the PyPI long description. Every public method should have a copy-paste usage example there.
+- **Version Control Best Practices**: Use clear commit messages and feature branches; describe what changed and why in PRs. See `CONTRIBUTING.md`.
+- **Dependency Management**: Keep dependencies minimal and pinned. The pins in `requirements.txt` and `setup.py`'s `install_requires` must stay in sync; document why a dependency is added.
+- **Versioning**: Bump the `version` in `setup.py` for every release (semantic versioning) and tag the release.
+- **Release Process**: Build with `python setup.py sdist bdist_wheel`, then publish with `twine upload dist/*`.
+- **Environment Configuration**: Never commit secrets. The library needs no credentials, but any future config (timeouts, user-agent, TLS verification) should be parameters/env vars, not hardcoded.
+- **Changelog**: Note significant changes per release so users can see what each version adds or fixes.

--- a/agent-os/standards/global/error-handling.md
+++ b/agent-os/standards/global/error-handling.md
@@ -1,0 +1,78 @@
+# Error Handling Standards
+
+Error handling for `stocksurferbd`'s scrapers — the two failure modes that matter are **network failures** (the DSE/CSE site is down, slow, or refuses the request) and **parse failures** (the page loaded but its HTML layout changed or a symbol returned no data).
+
+---
+
+## General Principles
+
+- **Fail clearly, with the symbol/market in the message.** A user running over hundreds of symbols needs to know exactly which one failed and why. The fundamentals scraper already does this: `raise Exception(f"Data fetch error for: {symbol}")`.
+- **Distinguish network errors from parse errors.** They have different fixes (retry vs. update the parser). Prefer typed exceptions over bare `Exception`.
+- **Don't let one bad symbol abort a batch.** Batch drivers should catch per-symbol, log, and continue (as `fetch_company_data.py` does).
+- **Set request timeouts.** `requests.get(...)` without a timeout can hang forever; always pass `timeout=`.
+
+---
+
+## Suggested Exception Types
+
+Bare `Exception` is used today; prefer a small hierarchy so callers can react:
+
+```python
+class StockSurferError(Exception):
+    """Base error for the library."""
+
+class FetchError(StockSurferError):
+    """Network/HTTP failure fetching a source page."""
+
+class ParseError(StockSurferError):
+    """Page fetched, but expected table/field was missing or malformed."""
+```
+
+---
+
+## Fetch Pattern
+
+```python
+def _get(self, url):
+    try:
+        resp = requests.get(url, timeout=30)
+        resp.raise_for_status()
+    except requests.RequestException as e:
+        raise FetchError(f"Failed to fetch {url}: {e}") from e
+    return resp
+```
+
+- Catch `requests.RequestException` (covers timeouts, connection errors, HTTP errors via `raise_for_status`).
+- Wrap in `FetchError` so callers don't need to import `requests`.
+- Optionally retry transient failures with simple backoff before giving up.
+
+---
+
+## Parse Pattern
+
+The scrapers locate tables by CSS class and index into rows/cells positionally. When a layout changes, those lookups return `None` or raise `IndexError` deep in a comprehension. Guard the boundaries:
+
+```python
+table = soup.find("table", attrs={"class": EXPECTED_CLASS})
+if table is None:
+    raise ParseError(f"Expected table not found for {symbol} — page layout may have changed")
+```
+
+- Check that `find(...)` returned something before using it.
+- Validate row/column counts before indexing, so the error names the problem instead of surfacing a raw `IndexError`.
+- Treat `'--'` / empty cells as missing data and normalise them (the `parse_float`/`parse_int` helpers already map `'--'` → `0`) — but be deliberate about whether `0` or "missing" is the right value for the field.
+
+---
+
+## Batch Driver Pattern
+
+```python
+for symbol in symbols:
+    try:
+        loader.save_company_data(symbol, path="company_info")
+    except StockSurferError as e:
+        print(f"Skipping {symbol}: {e}")
+```
+
+- Catch the library's base error, report it, and keep going.
+- Don't swallow `KeyboardInterrupt` / `SystemExit` — only catch `StockSurferError` (or `Exception` as a last resort, but log it).

--- a/agent-os/standards/global/tech-stack.md
+++ b/agent-os/standards/global/tech-stack.md
@@ -1,0 +1,71 @@
+# stocksurferbd Tech Stack
+
+> A small, dependency-light Python library. No web framework, database, or services. Versions are pinned in `requirements.txt` and `stocksurferbd_pkg/setup.py`.
+
+---
+
+## Runtime Dependencies
+
+| Library | Version | Usage |
+|---------|---------|-------|
+| requests | 2.32.3 | Fetching DSE/CSE pages |
+| beautifulsoup4 | 4.9.3 | Parsing tables out of page HTML |
+| pandas | 2.2.2 | Tabular normalisation, Excel I/O |
+| openpyxl | 3.1.5 | `.xlsx` writer engine for pandas |
+| python-dateutil | (via requests stack) | Parsing dates from page text |
+| matplotlib | 3.9.2 | Rendering backend |
+| mplfinance | 0.12.x | Candlestick/volume plotting |
+| pyti | 0.2.2 | Technical indicators for plots |
+| tapy | 1.9.1 | Technical-analysis indicators for plots |
+
+---
+
+## Build & Publish
+
+| Tool | Usage |
+|------|-------|
+| setuptools | `setup.py sdist bdist_wheel` |
+| wheel | Build distributions |
+| twine | Upload to PyPI |
+
+```
+python setup.py sdist bdist_wheel
+twine upload dist/*
+```
+
+---
+
+## Package Structure
+
+```
+stocksurferbd/                  # repo root
+├── requirements.txt            # pinned runtime + build deps
+├── README.md                   # usage docs (also the PyPI long description)
+├── fetch_*.py, plot_*.py       # example/driver scripts
+└── stocksurferbd_pkg/
+    ├── setup.py                # packaging metadata
+    └── stocksurferbd/          # the importable package
+        ├── __init__.py         # exports PriceData, FundamentalData, CandlestickPlot
+        ├── price_data_scraper.py
+        ├── fundamental_data_scraper.py
+        └── price_plots.py
+```
+
+---
+
+## Public API
+
+| Class | Methods |
+|-------|---------|
+| `PriceData` | `save_history_data`, `save_current_data` |
+| `FundamentalData` | `save_company_data` |
+| `CandlestickPlot` | `show_plot` |
+
+---
+
+## Constraints
+
+- **Python**: `>=3.10`
+- **No backend services**: the library runs locally; no DB, no server, no async runtime.
+- **Public data only**: scrapes the same DSE/CSE pages a browser would.
+- **Output**: `.xlsx` files (pandas + openpyxl) and `matplotlib`/`mplfinance` figures.

--- a/agent-os/standards/global/validation.md
+++ b/agent-os/standards/global/validation.md
@@ -1,0 +1,67 @@
+# Validation Standards
+
+Input validation for `stocksurferbd`. The library's inputs are small and well-defined — stock symbols, market codes, file paths, and plotting parameters — so validation is about catching bad arguments early with a clear message, not heavy schema work.
+
+---
+
+## General Principles
+
+- Validate arguments at the public method boundary, before any network call.
+- Fail with a specific, actionable message that names the bad argument and the allowed values.
+- Keep allowed values in one place (constants), not retyped per check.
+
+---
+
+## Market Code
+
+Only `'DSE'` and `'CSE'` are valid. The library already enforces this — keep doing so for every market-taking method:
+
+```python
+VALID_MARKETS = ("DSE", "CSE")
+
+if market not in VALID_MARKETS:
+    raise IOError("Invalid Stock Market! Possible values are- CSE, DSE")
+```
+
+Prefer comparing against the shared constant rather than literals, and accept case-insensitively if convenient (`market.upper()`).
+
+---
+
+## Symbol
+
+- Require a non-empty string; strip whitespace and upper-case it before building the URL.
+- Don't assume the symbol exists — an unknown symbol returns a page without the expected tables, which should surface as a `ParseError` (see error-handling), not a confusing `IndexError`.
+
+```python
+if not symbol or not symbol.strip():
+    raise ValueError("symbol must be a non-empty string")
+symbol = symbol.strip().upper()
+```
+
+---
+
+## File Paths
+
+- `save_*` methods take a directory/file name. Ensure the target directory exists (or create it) before writing, so `to_excel` doesn't fail with an opaque error.
+- Use `os.path.join` for portability (already done).
+
+---
+
+## Plotting Parameters (`CandlestickPlot.show_plot`)
+
+- `data_n`: positive integer (number of recent points to plot).
+- `resample`: boolean.
+- `step`: only meaningful when `resample=True`; expect a pandas offset string like `'3D'`, `'7D'`. Validate the format and ignore/warn if `resample=False`.
+
+```python
+if data_n <= 0:
+    raise ValueError("data_n must be a positive integer")
+if resample and not step:
+    raise ValueError("step is required when resample=True (e.g. '3D', '7D')")
+```
+
+---
+
+## Data-cell normalisation
+
+Scraped cells use `','` thousands separators and `'--'` for missing values. The `parse_float`/`parse_int` helpers normalise these. When adding new fields, route every numeric cell through these helpers so output types stay consistent, and decide explicitly whether a missing value should become `0` or be left blank.

--- a/agent-os/standards/index.yml
+++ b/agent-os/standards/index.yml
@@ -1,0 +1,24 @@
+# Agent OS Standards Index
+# stocksurferbd - Python library for DSE/CSE market data
+
+python:
+  coding:
+    description: Python coding standards - SOLID, flat design, type hints, naming, no magic strings
+
+global:
+  coding-style:
+    description: Formatting rules, naming consistency, DRY, dead-code removal
+  commenting:
+    description: Code documentation and commenting standards
+  conventions:
+    description: Project structure, version control, dependency management
+  error-handling:
+    description: Error handling for scrapers - network failures, parse failures, missing data
+  tech-stack:
+    description: stocksurferbd tech stack - requests, BeautifulSoup, pandas, mplfinance
+  validation:
+    description: Input validation - symbols, market codes, plotting parameters
+
+testing:
+  test-writing:
+    description: Test organization - parsing tests against saved HTML fixtures, mocking HTTP

--- a/agent-os/standards/python/coding.md
+++ b/agent-os/standards/python/coding.md
@@ -1,0 +1,133 @@
+# Python Coding Standards
+
+Guidelines for writing clean, maintainable Python in the `stocksurferbd` library. The library is small — favour clarity and predictable data shapes over abstraction.
+
+---
+
+## Core Philosophy
+
+### Readability over cleverness
+Code should read like prose. The scrapers do real work parsing messy HTML; keep the *intent* obvious even when the parsing is fiddly.
+
+### Flat over nested
+Prefer early returns and guard clauses over deep nesting. Validate inputs and check that a `find(...)` returned something, then proceed on the happy path.
+
+### Small over large
+A function should do one thing. The big "build a dict from positional table cells" blocks are the hardest part of this codebase — splitting fetch / parse / assemble / save keeps each piece testable.
+
+### Explicit over implicit
+No magic strings for URLs, table classes, market codes, or column names — name them once as constants.
+
+---
+
+## SOLID, lightly applied
+
+This is a library, not a service — don't over-engineer. But the spirit still helps:
+
+- **Single Responsibility** — separate *fetching* (HTTP), *parsing* (HTML → rows), *assembling* (rows → DataFrame), and *saving* (DataFrame → file). Today `get_company_df` mixes fetch + parse + assemble; pulling fetch into its own helper makes parsing testable against saved HTML.
+- **Open/Closed** — adding a new market or data field should mean adding a method/constant, not editing a long `if/elif` chain.
+- **Dependency inversion** — let callers pass in things that vary (e.g. an HTTP session, a timeout) rather than hardcoding them, so tests can inject a fixture.
+
+Skip protocols, generics, and service-layer ceremony unless a real need appears.
+
+---
+
+## No magic strings — use constants
+
+URLs, CSS class names, market codes, and output column names are repeated literals. Keep them as named constants (as `PriceData` already does for its URLs):
+
+```python
+class PriceData:
+    HISTORY_URL_DSE = "https://www.dsebd.org/day_end_archive.php?endDate=<date>&archive=data"
+    CURRENT_PRICE_URL_DSE = "https://www.dsebd.org/latest_share_price_scroll_l.php"
+    VALID_MARKETS = ("DSE", "CSE")
+```
+
+For closed sets like market codes, define them once and reference them everywhere (validation, branching, docs).
+
+---
+
+## Flat code design
+
+### Guard clauses and early returns
+
+```python
+def save_current_data(self, file_path="", file_name="...", market="DSE"):
+    if market not in self.VALID_MARKETS:
+        raise IOError("Invalid Stock Market! Possible values are- CSE, DSE")
+    # happy path, flat
+```
+
+### Check parser results before indexing
+
+The scrapers index into tables/rows positionally. A missing table currently surfaces as a deep `IndexError`. Guard it:
+
+```python
+table = soup.find("table", attrs={"class": EXPECTED_CLASS})
+if table is None:
+    raise ParseError(f"Expected table not found for {symbol}")
+rows = table.find_all("tr")
+```
+
+---
+
+## Naming conventions
+
+### Functions: verb_noun
+
+```python
+def save_history_data(...): ...
+def parse_current_prices_dse(...): ...
+def get_company_df(...): ...
+```
+
+Avoid vague names like `process`, `handle`, or `do_it`.
+
+### Classes: clear nouns
+
+`PriceData`, `FundamentalData`, `CandlestickPlot` — good. Avoid `Manager`, `Helper`, `Utils` grab-bags.
+
+### Variables: descriptive, no cryptic abbreviations
+
+`latest_trading_date`, `table_rows`, `dict_list` are fine. Avoid `df1`, `tmp`, `x` for anything that lives more than a line or two.
+
+---
+
+## Type hints
+
+Add type hints to public methods and shared helpers — they document the data shapes (which are easy to lose track of in scraping code) and enable IDE/`mypy` checks:
+
+```python
+def parse_float(str_val: str) -> float: ...
+def save_history_data(self, symbol: str, file_path: str = "",
+                      file_name: str = "history_data.xlsx", market: str = "DSE") -> None: ...
+def parse_current_prices_dse(self, soup: BeautifulSoup) -> list[dict]: ...
+```
+
+---
+
+## Data shapes
+
+- Scraped rows are normalised to `list[dict]`, then to a `pandas.DataFrame`. Keep the dict keys / column names stable and centralised — they are the library's de-facto output schema.
+- Route every numeric cell through `parse_float` / `parse_int` so types are consistent and `','`/`'--'` are handled uniformly.
+- Prefer returning a `DataFrame` from the "get" layer and writing files in a thin "save" layer, so callers can use the data without round-tripping through Excel.
+
+---
+
+## Quick checklist
+
+### Before every function
+- [ ] Clear `verb_noun` name?
+- [ ] One responsibility (not fetch + parse + save in one)?
+- [ ] Type-hinted params and return?
+- [ ] Inputs validated / parser results guarded before indexing?
+
+### Before every string literal
+- [ ] Is this a URL / CSS class / market code / column name that should be a constant?
+- [ ] Does a constant for it already exist?
+
+### Before committing
+- [ ] No new hardcoded URLs or magic strings
+- [ ] `requests.get` calls have a `timeout`
+- [ ] Dead code / commented-out debug `print`s removed
+- [ ] `requirements.txt` and `setup.py` pins still in sync

--- a/agent-os/standards/testing/test-writing.md
+++ b/agent-os/standards/testing/test-writing.md
@@ -1,0 +1,125 @@
+# Testing Standards
+
+Testing patterns for `stocksurferbd`. The hard, breakage-prone part is **HTML parsing**, so the highest-value tests run the parsers against *saved HTML fixtures* — no live network needed.
+
+---
+
+## General Principles
+
+- **Test the parsers, not the network.** Save real DSE/CSE pages once as fixtures and assert the parsers turn them into the expected rows/columns. This is what actually breaks when the sites change.
+- **Don't hit live sites in tests.** Mock `requests.get` (or inject a session) so the suite is fast and deterministic, and doesn't depend on the exchange being up.
+- **Test behaviour, not internals.** Assert on the returned `DataFrame`/`list[dict]` shape and values, not on private steps.
+- **Cover the failure modes.** Missing table → clear `ParseError`; bad market code → `IOError`; `'--'`/empty cells normalised correctly.
+
+---
+
+## Suggested Layout
+
+```
+stocksurferbd_pkg/
+└── stocksurferbd/
+    ├── price_data_scraper.py
+    ├── fundamental_data_scraper.py
+    └── price_plots.py
+tests/
+├── conftest.py                  # shared fixtures, fixture-loading helpers
+├── fixtures/
+│   ├── dse_company_aci.html     # saved displayCompany.php page
+│   ├── dse_current_prices.html  # saved latest_share_price page
+│   ├── dse_history_aci.html
+│   └── cse_current_prices.html
+├── test_price_data.py
+├── test_fundamental_data.py
+└── test_price_plots.py
+```
+
+---
+
+## Loading HTML Fixtures
+
+```python
+# conftest.py
+import pytest
+from pathlib import Path
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+@pytest.fixture
+def dse_company_html():
+    return (FIXTURES / "dse_company_aci.html").read_text(encoding="utf-8")
+```
+
+---
+
+## Parser Tests (against fixtures)
+
+```python
+# test_fundamental_data.py
+from bs4 import BeautifulSoup
+from stocksurferbd import FundamentalData
+
+def test_parses_company_rows(dse_company_html):
+    soup = BeautifulSoup(dse_company_html, "html.parser")
+    company, fin_perf = FundamentalData.parse_company_data_rows(soup, "ACI")
+
+    assert company["symbol"] == "ACI"
+    assert company["company_info"]["market_cap"]          # present, non-empty
+    assert fin_perf["fin_perf_info"]                       # financial table parsed
+
+def test_missing_table_raises_parse_error():
+    soup = BeautifulSoup("<html><body>no tables</body></html>", "html.parser")
+    with pytest.raises(Exception):                          # ParseError once introduced
+        FundamentalData.parse_company_data_rows(soup, "ACI")
+```
+
+```python
+# test_price_data.py
+from stocksurferbd import PriceData
+
+def test_invalid_market_raises():
+    with pytest.raises(IOError):
+        PriceData().save_current_data(market="NYSE")
+
+def test_parse_float_handles_commas_and_dashes():
+    assert PriceData.parse_float("1,234.50") == 1234.50
+    assert PriceData.parse_float("--") == 0.0
+```
+
+---
+
+## Mocking HTTP
+
+Mock at the `requests` boundary so no real request is made:
+
+```python
+from unittest.mock import patch
+
+def test_current_data_uses_dse_url(dse_current_html, tmp_path):
+    with patch("stocksurferbd.price_data_scraper.requests.get") as mock_get:
+        mock_get.return_value.text = dse_current_html
+        PriceData().save_current_data(
+            file_path=str(tmp_path), file_name="out.xlsx", market="DSE"
+        )
+        assert (tmp_path / "out.xlsx").exists()
+```
+
+(Better still: refactor fetching into an injectable helper/session so tests pass a fake instead of patching.)
+
+---
+
+## Plotting Tests
+
+- Use a non-interactive matplotlib backend (`matplotlib.use("Agg")`) so tests don't open windows.
+- Assert that `show_plot` runs without error on a small fixture DataFrame and respects `data_n` / `resample` / `step`; pixel-perfect image assertions aren't worth the maintenance.
+
+---
+
+## Running Tests
+
+```bash
+pip install -r requirements.txt pytest
+pytest
+pytest --cov=stocksurferbd        # if pytest-cov is installed
+```
+
+Refresh the HTML fixtures whenever the DSE/CSE pages change — a failing parser test is the early-warning that the live scraper is about to break.

--- a/stocksurferbd_pkg/__init__.py
+++ b/stocksurferbd_pkg/__init__.py
@@ -6,4 +6,5 @@ __copyright__ = "Copyright (c) 2024 The Python Packaging Authority"
 
 from .stocksurferbd import PriceData
 from .stocksurferbd import FundamentalData
+from .stocksurferbd import BlockTradeData
 from .stocksurferbd import CandlestickPlot

--- a/stocksurferbd_pkg/setup.py
+++ b/stocksurferbd_pkg/setup.py
@@ -5,7 +5,7 @@ with open("../README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="stocksurferbd",
-    version="0.1.3",
+    version="1.0.0",
     author="Sk Farhad",
     author_email="sk.farhad.eee@gmail.com",
     description="A Python library for downloading stock market data of Dhaka Stock"

--- a/stocksurferbd_pkg/stocksurferbd/__init__.py
+++ b/stocksurferbd_pkg/stocksurferbd/__init__.py
@@ -6,4 +6,5 @@ __copyright__ = "Copyright (c) 2024 The Python Packaging Authority"
 
 from .price_data_scraper import PriceData
 from .fundamental_data_scraper import FundamentalData
+from .block_trade_scraper import BlockTradeData
 from .price_plots import CandlestickPlot

--- a/stocksurferbd_pkg/stocksurferbd/block_trade_scraper.py
+++ b/stocksurferbd_pkg/stocksurferbd/block_trade_scraper.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python
+
+__author__ = "Sk Farhad"
+__copyright__ = "Copyright (c) 2024 The Python Packaging Authority"
+
+import os
+import re
+
+import pandas as pd
+from bs4 import BeautifulSoup
+
+from .fundamental_data_scraper import FundamentalData
+from .utils import HttpScraper, parse_float, parse_int
+
+
+class BlockTradeData(HttpScraper):
+    """Block-transaction data for the Dhaka Stock Exchange (DSE).
+
+    Two complementary sources:
+
+    1. ``get_block_trades_df`` / ``save_block_trade_data`` - the *current day's*
+       actual block transactions (all symbols) parsed from the DSE market
+       statistics page. DSE does not publish a historical block-trade archive,
+       so run this daily to accumulate history.
+    2. ``get_block_trade_news_df`` / ``save_block_trade_news_data`` - a
+       per-company historical proxy built from block-market related news
+       (e.g. director/sponsor block-market buy declarations) over the last N
+       years. These are disclosures, not raw trade tickets.
+    """
+
+    MARKET_STATS_URL_DSE = 'https://www.dsebd.org/market-statistics.php'
+    BLOCK_KEYWORDS = ('block',)
+    VALID_MARKETS = ('DSE',)
+
+    BLOCK_COLUMNS = [
+        'DATE', 'TRADING_CODE', 'MAX_PRICE', 'MIN_PRICE',
+        'TRADES', 'QUANTITY', 'VALUE_MN',
+    ]
+
+    @staticmethod
+    def parse_block_trades_dse(soup):
+        """Parse the 'PRICES IN BLOCK TRANSACTIONS' section into records.
+
+        The section is whitespace-aligned text with columns:
+        Instr Code, Max Price, Min Price, Trades, Quantity, Value(In Mn).
+        Returns a list of dicts keyed by ``BLOCK_COLUMNS``. An empty list is a
+        valid result (a day with no block trades).
+        """
+        text = soup.get_text('\n')
+        header = re.search(
+            r'PRICES IN BLOCK TRANSACTIONS\s*:\s*([0-9-]+)', text
+        )
+        if header is None:
+            raise Exception('Block transactions section not found on page')
+        trade_date = header.group(1)
+
+        records = []
+        started = False
+        for line in text[header.end():].splitlines():
+            line = line.strip()
+            if not line or line.startswith('='):
+                continue
+            if line.lower().startswith('instr'):
+                started = True
+                continue
+            if not started:
+                continue
+            # A data row is: CODE max min trades quantity value. The code may
+            # contain special chars (e.g. KAY&QUE); split the 5 numeric columns
+            # off the right so the rest is the code. Non-matching lines (footer
+            # text, stray separators) are skipped, not treated as table-end.
+            parts = line.rsplit(None, 5)
+            if len(parts) == 6 and all(re.match(r'^[0-9.,]+$', p) for p in parts[1:]):
+                records.append({
+                    'DATE': trade_date,
+                    'TRADING_CODE': parts[0],
+                    'MAX_PRICE': parse_float(parts[1]),
+                    'MIN_PRICE': parse_float(parts[2]),
+                    'TRADES': parse_int(parts[3]),
+                    'QUANTITY': parse_int(parts[4]),
+                    'VALUE_MN': parse_float(parts[5]),
+                })
+        if not started:
+            print('Warning: block transactions column header not found; '
+                  'page layout may have changed.')
+        return records
+
+    def get_block_trades_df(self, market='DSE', symbol=None):
+        """Current-day block transactions for all symbols (or one ``symbol``)."""
+        if market not in self.VALID_MARKETS:
+            raise IOError('Invalid Stock Market! Possible values are- DSE')
+        target_page = self._get(self.MARKET_STATS_URL_DSE)
+        page_html = BeautifulSoup(target_page.text, 'html.parser')
+        records = self.parse_block_trades_dse(page_html)
+        df_block = pd.DataFrame(records, columns=self.BLOCK_COLUMNS)
+        if symbol is not None and not df_block.empty:
+            df_block = df_block[
+                df_block['TRADING_CODE'] == symbol
+            ].reset_index(drop=True)
+        return df_block
+
+    def save_block_trade_data(self, file_path='', file_name='block_trade_data.xlsx',
+                              market='DSE', symbol=None):
+        block_df = self.get_block_trades_df(market=market, symbol=symbol)
+        block_df.to_excel(os.path.join(file_path, file_name), index=False)
+        print("Block trade data download completed!")
+
+    def get_block_trade_news_df(self, symbol, years=2):
+        """Historical block-market related disclosures for a company.
+
+        Filters the company news feed (last ``years`` years) down to items that
+        mention block-market activity. Returns a DataFrame with the same columns
+        as the news feed (symbol, date, title, news).
+        """
+        fundamental = FundamentalData(
+            verify=self.verify, session=self.session, timeout=self.timeout
+        )
+        news_df = fundamental.get_news_df(symbol, years=years)
+        if news_df.empty:
+            return news_df
+        haystack = (
+            news_df['title'].fillna('') + ' ' + news_df['news'].fillna('')
+        ).str.lower()
+        mask = haystack.apply(
+            lambda text: any(kw in text for kw in self.BLOCK_KEYWORDS)
+        )
+        return news_df[mask].reset_index(drop=True)
+
+    def save_block_trade_news_data(self, symbol, path='', years=2):
+        news_df = self.get_block_trade_news_df(symbol, years=years)
+        if news_df.empty:
+            print(f"No block trade news found for {symbol}.")
+            return
+        news_df.to_excel(
+            os.path.join(path, f'{symbol}_block_trade_news.xlsx'), index=False
+        )
+        print(f"Block trade news download completed for {symbol}!")

--- a/stocksurferbd_pkg/stocksurferbd/fundamental_data_scraper.py
+++ b/stocksurferbd_pkg/stocksurferbd/fundamental_data_scraper.py
@@ -4,15 +4,20 @@ __author__ = "Sk Farhad"
 __copyright__ = "Copyright (c) 2024 The Python Packaging Authority"
 
 import os
+import urllib.parse as parse_url
+from datetime import datetime
 import pandas as pd
 from bs4 import BeautifulSoup
-import requests
 from dateutil import parser
+from dateutil.relativedelta import relativedelta
+
+from .utils import HttpScraper
 
 
-class FundamentalData(object):
+class FundamentalData(HttpScraper):
     DSE_COMPANY_URL = "https://dsebd.org/displayCompany.php?name="
     CURRENT_PRICE_URL = 'https://www.dsebd.org/dseX_share.php'
+    NEWS_URL = "https://www.dsebd.org/old_news.php?archive=news&criteria=3&inst="
 
     @staticmethod
     def parse_float(str_val):
@@ -29,7 +34,7 @@ class FundamentalData(object):
         return int(new_val)
 
     @staticmethod
-    def append_company(company_info, fin_interim_info, symbol):
+    def append_company(company_info, fin_interim_info, symbol, meta=None):
         company_dict = {
             'symbol': symbol,
             'auth_capital': company_info['basic'][0][0],
@@ -94,6 +99,9 @@ class FundamentalData(object):
             'eps_cop_diluted_9m': fin_interim_info['main'][9][5],
             'eps_cop_diluted_yr': fin_interim_info['main'][9][6],
         }
+        # Append company identity/links as extra columns (backward compatible:
+        # existing columns keep their order, new ones are added at the end).
+        company_dict.update(meta or {})
         df_company = pd.DataFrame(company_dict, index=[0])
 
         return df_company
@@ -162,6 +170,101 @@ class FundamentalData(object):
         )
 
         return df_fin_perf
+
+    @staticmethod
+    def _table_after_heading(soup, heading_text):
+        heading_text = heading_text.lower()
+        for head in soup.find_all(["h2", "h3", "h4"]):
+            if heading_text in " ".join(head.get_text().split()).lower():
+                return head.find_next("table")
+        return None
+
+    @staticmethod
+    def parse_company_meta(soup):
+        """Company identity and disclosure links from the company page.
+
+        Returns a dict with company_name, website, address,
+        financial_statement_link and price_sensitive_info_link. Parsing is
+        label-based (not positional) and never raises: any field that cannot be
+        found defaults to '-' so the core company/financial extraction is
+        unaffected.
+        """
+        meta = {
+            'company_name': '-',
+            'website': '-',
+            'address': '-',
+            'financial_statement_link': '-',
+            'price_sensitive_info_link': '-',
+        }
+        try:
+            for head in soup.find_all("h2"):
+                text = " ".join(head.get_text().split())
+                if text.lower().startswith("company name"):
+                    meta['company_name'] = text.split(":", 1)[1].strip()
+                    break
+
+            address_table = FundamentalData._table_after_heading(
+                soup, "Address of the Company"
+            )
+            if address_table is not None:
+                for row in address_table.find_all("tr"):
+                    cells = [" ".join(td.get_text(" ").split()) for td in row.find_all(["td", "th"])]
+                    if not cells:
+                        continue
+                    if cells[0] == "Web Address":
+                        link = row.find("a", href=True)
+                        meta['website'] = link['href'] if link else (cells[1] if len(cells) > 1 else '-')
+                    elif cells[0] == "Address" and len(cells) >= 3:
+                        meta['address'] = cells[2]
+
+            for row in soup.find_all("tr"):
+                cells = [" ".join(td.get_text(" ").split()) for td in row.find_all(["td", "th"])]
+                if not cells:
+                    continue
+                label = cells[0]
+                if label.startswith("Details of Financial Statement"):
+                    link = row.find("a", href=True)
+                    meta['financial_statement_link'] = link['href'] if link else (cells[1] if len(cells) > 1 else '-')
+                elif label.startswith("Price Sensitive Information"):
+                    link = row.find("a", href=True)
+                    meta['price_sensitive_info_link'] = link['href'] if link else (cells[1] if len(cells) > 1 else '-')
+        except Exception as e:
+            print(f"Company meta parse warning: {e}")
+        return meta
+
+    @staticmethod
+    def parse_news_rows(soup, symbol):
+        """Parse the company news feed (``table-news``) into a list of records.
+
+        Each news item is a block of label/value rows (Trading Code, News
+        Title, News, Post Date). Returns a list of dicts with keys symbol,
+        date, title and news.
+        """
+        records = []
+        table = soup.find("table", class_="table-news")
+        if table is None:
+            return records
+        current = {}
+        for row in table.find_all("tr"):
+            cells = [" ".join(td.get_text(" ").split()) for td in row.find_all(["td", "th"])]
+            if len(cells) < 2:
+                continue
+            label, value = cells[0].rstrip(":").strip(), cells[1]
+            if label == "Trading Code":
+                if current:
+                    records.append(current)
+                current = {'symbol': symbol, 'date': '', 'title': '', 'news': ''}
+            elif not current:
+                continue
+            elif label == "News Title":
+                current['title'] = value
+            elif label == "News":
+                current['news'] = value
+            elif label == "Post Date":
+                current['date'] = value
+        if current:
+            records.append(current)
+        return records
 
     @staticmethod
     def parse_company_data_rows(soup, symbol):
@@ -262,16 +365,18 @@ class FundamentalData(object):
     def get_company_df(self, symbol):
         df_company_all = pd.DataFrame()
         df_fin_perf_all = pd.DataFrame()
-        full_url = self.DSE_COMPANY_URL + symbol
-        target_page = requests.get(full_url)
+        full_url = self.DSE_COMPANY_URL + parse_url.quote(symbol)
+        target_page = self._get(full_url)
         page_html = BeautifulSoup(target_page.text, 'html.parser')
         dict_company, dict_fin_perf = self.parse_company_data_rows(
             page_html, symbol
         )
+        company_meta = self.parse_company_meta(page_html)
         df_company = self.append_company(
             company_info=dict_company['company_info'],
             fin_interim_info=dict_company['fin_interim_info'],
-            symbol=symbol
+            symbol=symbol,
+            meta=company_meta
         )
         df_company_all = pd.concat([df_company_all, df_company])
         df_fin_perf = self.append_fin_perf(
@@ -286,3 +391,35 @@ class FundamentalData(object):
         company_df, fin_df = self.get_company_df(symbol)
         company_df.to_excel(os.path.join(path, f'{symbol}_company_data.xlsx'), index=False)
         fin_df.to_excel(os.path.join(path, f'{symbol}_financial_data.xlsx'), index=False)
+
+    def get_news_df(self, symbol, years=2):
+        """Company news/disclosures from the DSE news archive.
+
+        Returns a DataFrame with columns symbol, date, title and news, sorted
+        newest first. ``years`` limits the result to news posted within the
+        last N years (rolling window from today); pass ``years=None`` to return
+        every available record.
+        """
+        full_url = self.NEWS_URL + parse_url.quote(symbol)
+        target_page = self._get(full_url)
+        page_html = BeautifulSoup(target_page.text, 'html.parser')
+        records = self.parse_news_rows(page_html, symbol)
+        df_news = pd.DataFrame(records, columns=['symbol', 'date', 'title', 'news'])
+        if df_news.empty:
+            return df_news
+        df_news['date'] = pd.to_datetime(df_news['date'], errors='coerce')
+        df_news = df_news.dropna(subset=['date'])
+        if years is not None:
+            cutoff = pd.Timestamp(datetime.now().date() - relativedelta(years=years))
+            df_news = df_news[df_news['date'] >= cutoff]
+        df_news = df_news.sort_values('date', ascending=False).reset_index(drop=True)
+        df_news['date'] = df_news['date'].dt.date
+        return df_news
+
+    def save_news_data(self, symbol, path='', years=2):
+        news_df = self.get_news_df(symbol, years=years)
+        if news_df.empty:
+            print(f"No news data found for {symbol}.")
+            return
+        news_df.to_excel(os.path.join(path, f'{symbol}_news_data.xlsx'), index=False)
+        print(f"News download completed for {symbol}!")

--- a/stocksurferbd_pkg/stocksurferbd/price_data_scraper.py
+++ b/stocksurferbd_pkg/stocksurferbd/price_data_scraper.py
@@ -8,13 +8,14 @@ import csv
 
 from bs4 import BeautifulSoup
 import pandas as pd
-import requests
 import datetime
 from dateutil import parser
 import urllib.parse as parse_url
 
+from .utils import HttpScraper
 
-class PriceData(object):
+
+class PriceData(HttpScraper):
     HISTORY_URL_DSE = "https://www.dsebd.org/day_end_archive.php?endDate=<date>&archive=data"
     HISTORY_URL_CSE = "https://www.cse.com.bd/company/company_graph_6m/"
     CURRENT_PRICE_URL_DSE = 'https://www.dsebd.org/latest_share_price_scroll_l.php'
@@ -58,7 +59,7 @@ class PriceData(object):
 
     def parse_price_history_dse(self, symbol):
         full_url = self.get_history_url() + "&inst=" + parse_url.quote(symbol)
-        target_page = requests.get(full_url)
+        target_page = self._get(full_url)
         bs_data = BeautifulSoup(target_page.text, 'html.parser')
         dict_list = []
         stock_table = bs_data.find(
@@ -195,9 +196,7 @@ class PriceData(object):
 
     def parse_price_history_cse(self, symbol):
         full_url = self.HISTORY_URL_CSE + symbol
-        resp = requests.get(
-            full_url
-        )
+        resp = self._get(full_url)
 
         split1 = resp.text.split("volumeData.push([date, round(volume)]);")[1]
         split2 = split1.split("$(document).ready(function () {")[0]
@@ -264,15 +263,12 @@ class PriceData(object):
 
     def save_current_data(self, file_path='', file_name='dsebd_current_data.csv', market='DSE'):
         if market == 'DSE':
-            # target_page = requests.get(self.CKT_BREAKER_URL_DSE)
-            # fp_data = BeautifulSoup(target_page.text, 'html.parser')
-            # fp_dict = self.parse_floor_prices_dse(fp_data)
-            target_page = requests.get(self.CURRENT_PRICE_URL_DSE)
+            target_page = self._get(self.CURRENT_PRICE_URL_DSE)
             bs_data = BeautifulSoup(target_page.text, 'html.parser')
             current_data = self.parse_current_prices_dse(bs_data)
             full_path = os.path.join(file_path, file_name)
         elif market == 'CSE':
-            target_page = requests.get(self.CURRENT_PRICE_URL_CSE)
+            target_page = self._get(self.CURRENT_PRICE_URL_CSE)
             bs_data = BeautifulSoup(target_page.text, 'html.parser')
             current_data = self.parse_current_prices_cse(bs_data)
             full_path = os.path.join(file_path, file_name)

--- a/stocksurferbd_pkg/stocksurferbd/utils.py
+++ b/stocksurferbd_pkg/stocksurferbd/utils.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+
+__author__ = "Sk Farhad"
+__copyright__ = "Copyright (c) 2024 The Python Packaging Authority"
+
+"""Shared parsing helpers and HTTP base for the data scrapers."""
+
+import requests
+import urllib3
+
+
+def parse_float(str_val):
+    new_val = str_val.replace(',', '').replace('--', '0')
+    return float(new_val)
+
+
+def parse_int(str_val):
+    new_val = str_val.replace(',', '').replace('--', '0')
+    return int(new_val)
+
+
+class HttpScraper(object):
+    """Base class providing a shared, configurable HTTP fetch.
+
+    All scrapers fetch from the DSE/CSE public sites. This centralises the
+    request options so callers can control TLS verification, reuse a
+    ``requests.Session``, and set a timeout:
+
+        loader = PriceData(verify=False)          # DSE's cert chain is
+                                                  # incomplete in some envs
+        loader = FundamentalData(session=my_sess, timeout=60)
+
+    Defaults (``verify=True``, a fresh session, 30s timeout) keep the previous
+    behaviour, so ``PriceData()`` / ``FundamentalData()`` / ``BlockTradeData()``
+    work unchanged.
+    """
+
+    DEFAULT_TIMEOUT = 30
+
+    def __init__(self, verify=True, session=None, timeout=None):
+        self.verify = verify
+        self.timeout = self.DEFAULT_TIMEOUT if timeout is None else timeout
+        self.session = session if session is not None else requests.Session()
+        if not self.verify:
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+    def _get(self, url):
+        return self.session.get(url, timeout=self.timeout, verify=self.verify)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,32 @@
+import sys
+from pathlib import Path
+
+import pytest
+from bs4 import BeautifulSoup
+
+# Make the package importable when running pytest from the repo root.
+PKG_ROOT = Path(__file__).resolve().parent.parent / "stocksurferbd_pkg"
+if str(PKG_ROOT) not in sys.path:
+    sys.path.insert(0, str(PKG_ROOT))
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+
+
+def _load_soup(name):
+    html = (FIXTURES / name).read_text(encoding="utf-8")
+    return BeautifulSoup(html, "html.parser")
+
+
+@pytest.fixture
+def company_soup():
+    return _load_soup("dse_company_aci.html")
+
+
+@pytest.fixture
+def news_soup():
+    return _load_soup("dse_news_aci.html")
+
+
+@pytest.fixture
+def market_stats_soup():
+    return _load_soup("dse_market_statistics.html")

--- a/tests/fixtures/dse_company_aci.html
+++ b/tests/fixtures/dse_company_aci.html
@@ -1,0 +1,7067 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+	<title>Display Company Information | Dhaka Stock Exchange</title>
+ 	<meta name="description" content="">
+ 	<meta name="Author" content="Dhaka Stock Exchange" />	
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta http-equiv="X-UA-Compatible" content="IE=10; IE=9; IE=8; IE=7; IE=EDGE" />
+	<meta http-equiv="refresh" content="300;">
+	<link href="assets/imgs/favicon.ico" rel="shortcut icon">
+
+	<!-- <link rel="dns-prefetch" href="https://cdnjs.cloudflare.com/" > -->
+	<link rel="dns-prefetch" href="https://www.googletagmanager.com" >
+
+	<link async="async" href="assets/update/css/layout.css?v=0.1" rel="stylesheet" type="text/css">
+	<link async="async" href="assets/update/css/layout-responsive.css?v=0.1" rel="stylesheet" type="text/css">
+
+	<!-- <link async="async" href="assets/css/bootstrap.css" rel="stylesheet" type="text/css"> -->
+	<!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.1.3/css/bootstrap.min.css" integrity="sha512-GQGU0fMMi238uA+a/bdWJfpUGKUkBdgfFdgBm72SUQ6BeyWjoY/ton0tEjH+OSH9iP4Dfh+7HM0I9f5eR0L/4w==" crossorigin="anonymous" referrerpolicy="no-referrer" /> -->
+	<link rel="stylesheet" href="assets/update/bootstrap.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
+
+	<link async="async" href="assets/css/carousel.css" rel="stylesheet" type="text/css">
+	<link async="async" href="assets/css/font-awesome.css" rel="stylesheet" type="text/css"/>
+    <link async="async" href="assets/css/rotate-wheel.css" rel="stylesheet" type="text/css"/>
+    <link async="async" href="assets/css/jquery-ui.css" rel="stylesheet" type="text/css"/>
+
+    <!--custom Link -->
+    <link async="async" href="assets/css/custom-training.css" rel="stylesheet" type="text/css"/>
+
+    <!-- <script async="async" type="text/javascript" src="assets/js/dygraph-combined.js"></script> -->
+
+	<!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/dygraph/2.1.0/dygraph.min.js" integrity="sha512-opAQpVko4oSCRtt9X4IgpmRkINW9JFIV3An2bZWeFwbsVvDxEkl4TEDiQ2vyhO2TDWfk/lC+0L1dzC5FxKFeJw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script> -->
+	<script src="assets/update/dygraph.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+
+    <link async="async" href="assets/css/jquery.dataTables.min.css" rel="stylesheet" type="text/css">
+	
+	<!-- Global site tag (gtag.js) - Google Analytics -->
+	<script async src="https://www.googletagmanager.com/gtag/js?id=UA-70465433-1"></script>
+	<script>
+	  window.dataLayer = window.dataLayer || [];
+	  function gtag(){dataLayer.push(arguments);}
+	  gtag('js', new Date());
+
+	  gtag('config', 'UA-70465433-1');
+	</script>
+	<style type="text/css">
+		body {
+			font-family: Arial,sans-serif !important;
+			font-size: 12px !important;
+			--bs-body-line-height : 1.42857143 !important; /*Add 29-12-2021*/
+		}
+		.btn-primary {
+		    color: #fff;
+		    background-color: #337ab7 !important;
+		    border-color: #337ab7 !important;
+		}
+		.btn-primary:hover{
+		    background-color: #286090 !important;
+		    border-color: #286090 !important;
+		}
+		
+		.gray {
+			/*background: none !important;*/
+			display: flex !important;
+			text-align: justify;
+		}
+		.pre-footer .btn {
+			font-size: 11px;
+		}
+				
+		.nav-tabs .nav-item.show .nav-link, .nav-tabs .nav-link{
+			background-color: #EEEEEE !important;
+		}
+		.nav-tabs .nav-item.show .nav-link, .nav-tabs .nav-link.active{
+			background-color: #fff !important;
+		}
+
+		#RightBody {
+		    padding: 6px 5px 0 5px !important; /*Add 29-12-2021*/
+		    position :relative !important;
+		}
+		.signature-class {
+		    margin: 0 -5px !important; /*Add 29-12-2021*/
+		}
+		.main-signature {
+			margin-top: 160px;
+		}
+
+		table{
+			color: #5a5a5a !important; /*Add 29-12-2021*/
+		}
+
+		.form-control {
+		    padding : 0.25rem .75rem !important;
+		    font-size: 14px  !important;
+		}
+
+		.table>:not(:first-child) {
+		    border-top: 0 !important;
+		}
+		.background-yellow {
+		    background-color: #ff9 !important;
+		}
+		.category li a {
+		    color: #337ab7 !important;
+		}
+		.bg-danger {
+		    background-color: #f2dede !important;
+		}
+		.txt-al-l {
+			text-align: left !important;
+		}
+		.ml-10 {
+    		margin-left: 10%;
+		}
+		.pd-10 {
+			padding: 10px;
+		}
+        .tpb-10 div {
+            padding-bottom: 10px;
+        }
+		.pdt-10 {
+			padding-top: 10px;
+		}
+		.glance-table {
+			width: 80%; 
+			margin: auto;
+		}
+
+		@media (max-width: 768px){
+			.RightColmInner  {
+			    width: 100% !important;
+			}
+			.RightColmInner .list-group {
+			    margin-bottom: 50px;
+			}
+			.mb-50 {
+			    margin-bottom: 50px;
+			}
+			.wd-100 {
+				width: 100%;
+			}
+			.main-signature {
+				margin-top: 200px!important;
+			}
+			.brd {
+				border: 1px #ddd solid !important;
+			}
+			.glance-table {
+				width: 100% !important; 
+				margin: auto !important;
+			}
+			.ifra {
+				width: none;
+				height: none;
+			}
+			.wh-sp-nw-mobile {
+				white-space: nowrap;
+			}
+
+		}
+
+		@media (min-width: 768px){
+			.transfer-procedure dt {
+			    margin-left: 35px !important;
+			    padding-bottom: 0px !important;
+			}
+			.ifra {
+				width: 640px;
+				height: 385px;
+			}
+		}
+		.transfer-procedure h5 {
+			font-size: 14px !important;
+		}
+
+		.center-block {
+		    display: block;
+		    margin-right: auto;
+		    margin-left: auto;
+		}
+		.al-li{
+			--bs-gutter-x: 0 !important;
+		}
+		.cl-pr .table>:not(caption)>*>* {
+		    border-bottom-width: 0px !important;
+		}
+		.data-arc .data-archive-block {
+		    padding-bottom: 20px !important;
+     		border-bottom: none !important; 
+
+		}
+		.data-arc .btn-sm {
+		    font-size: 12px !important;
+		}
+
+		.rules-regulation li {
+			padding-right: 10px;
+			padding-left: 10px;
+		}
+		.pd-lr-0 li {
+			padding-right: 0px !important;
+			padding-left: 0px !important;
+		}
+		.list-group-item.active {
+		    z-index: 2;
+		    color: #fff;
+		    background-color: #337ab7;
+		    border-color: #337ab7;
+		}
+		.list-group-item {
+		    color: #555;
+		}
+		.tx-al-st {
+			text-align: start !important;
+		}
+		.training-heading a {
+		    color: #ffffff !important;
+		    text-shadow: black 0.5em 0.5em 0.2em !important;
+		    line-height: 4 !important;
+		}
+		.marquee-heading a {
+		    color: white !important;
+		    text-shadow: black 0.4em 0.4em 0.15em !important;
+		}
+		.mr-0 {
+			margin: 0 !important;
+		}
+		.pdb-10 {
+			padding-bottom: 10px;
+		}
+
+		.list li {
+		    padding-right: 0px !important; 
+		    padding-left: 0px !important;
+		}
+		.select-color {
+		    color: #337ab7 !important;
+		}
+		.pdb-5 {
+			padding-bottom: 5px;
+		}
+		.txt-left {
+			text-align: left !important;
+		}
+
+		/*For faq and career start*/
+        .newaccordion .panel {
+            margin-bottom: 20px;
+            background-color: #fff;
+            border: 1px solid #ddd;
+            box-shadow: 0 1px 1px rgba(0,0,0,.05);
+        }
+        .newaccordion .panel h2 {
+            margin-top: 20px;
+        }
+        .newaccordion .card {
+            border: none !important;
+        }
+        .newaccordion .btn-link {
+            color: #0d6efd;
+            text-decoration: none;
+        }
+        .newaccordion .card-header {
+            margin-bottom: 5px !important;
+            border-radius: 25px !important;
+        }
+        .f-14{
+        	font-size: 14px !important;
+        }
+		/*For faq and career end*/
+        .f-18{
+        	font-size: 18px !important;
+        }
+		/*For dse dept start*/
+        .dse-dept .panel-title {
+            padding: 10px !important;
+        }
+        .dse-dept .panel-title a {
+            color: #fff !important;
+        }
+		/*For dse dept start*/
+
+		.panel-body-dept {
+		    padding-top: 0 !important;
+		    padding-bottom: 0 !important;
+		    padding-left: 6px !important;
+		    padding-right: 6px !important;
+		}
+		.dept-collapse {
+			border: 1px #ddd solid !important;
+			margin-bottom: 4px !important;
+		}
+
+        .mw-100 img {
+        	max-width: 100% !important;
+        }
+        .mw-80 img {
+        	max-width: 80% !important;
+        }
+		.bg-primary {
+		    color: #fff !important;
+		    background-color: #337ab7 !important;
+		}
+		.sub-head {
+		    color: #039 !important;
+			font-size: 14px !important;
+		}
+		.wh-sp-nw {
+			white-space: nowrap;
+		}
+
+	</style>
+
+</head>
+<div id="scroll-top">
+	<a href="javascript:void(0)" class="smooth-scroll">
+		<i class="fa fa-arrow-up fa-2x"></i>
+	</a>
+</div><script type="text/javascript">
+// Function to validate and sanitize the input values
+function isValidInput(inst, duration, type) {
+    const validInst = inst.trim();
+    const instRegex = /^(KAY&QUE|AL-HAJTEX|AMCL\(PRAN\)|[A-Za-z0-9]{1,12})$/;
+    const validDuration = duration.trim();
+    const validDurations = ['1', '3', '6', '9', '12', '24'];
+
+    const validType = type.trim();
+    const validTypes = ['price', 'trd', 'vol'];
+
+    return instRegex.test(validInst) && validDurations.includes(validDuration) && validTypes.includes(validType);
+}
+
+// Function to show dynamic graph
+function show_graph(val){
+    value = val.split(",");
+    if(value.length === 3 && isValidInput(value[0], value[1], value[2])) {
+        var path = 'php_graph/monthly_graph.php?inst='+value[0]+'&duration='+value[1]+'&type='+value[2];
+        window.open(path, 'CompanyGraph', 'toolbar=no,width=850,height=520');
+    } else {
+        alert('Invalid input'); // Handle invalid input here
+    }
+}
+
+// Dynamic graph script finished
+
+function breakOut() {
+    if (self != top)
+        window.open("my URL", "_top", "");
+}
+</script>
+
+<body>
+<div class="containbox">
+  <div class="col-md-12 col-xs-12 col-sm-12">
+    <div class="_row">
+      <style type="text/css" media="print">
+
+.Header{
+        display: none;
+    }
+
+</style>
+<header class="Header">
+	<div class="HeaderTop">
+		<a href="https://bangla.dsebd.org/index.php" class="_a_link"> 
+			<img src="assets/images/bangla-songskoron-red.jpg">
+		</a>
+
+		<span class="time">Wednesday, June 17, 2026</span>
+		<span class="time">Current Time: 6:35:44 PM (BST)  </span>
+		<span class="time">Market Status: <span class="green"><b>Closed</b></span></span>
+	</div>
+
+	<div class="HeaderTopMobile col-md-12 col-sm-12 col-xs-18">
+		<span class="time col-md-4 col-sm-3 col-xs-6 pull-left "><a href="http://bangla.dsebd.org/index.php" class="_a_link"><img src="assets/images/bangla-songskoron-red.jpg" class="bngl"></a></span>
+		<span class="time col-md-4 col-sm-3 col-xs-6 pull-left ">Wed, 17 Jun, 26</span>
+		<span class="time col-md-4 col-sm-3 col-xs-6">6:35:44 PM </span>
+		<span class="time col-md-4 col-sm-3 col-xs-6 pull-right"><span class="green"><b>Closed</b></span></span>
+
+	</div>
+
+	<div class="HeaderBottom">
+		<div class="dsktp">
+			<a href="index.php"><img src="assets/images/plc-logo.png" class="logo png_img img-responsive" /></a>
+			<img src="assets/images/dse-name-plc.jpg" class="dsename png_img img-responsive" />
+			<!--img class="mUjib" src="assets/images/mujib10years.png" style="float: right;"-->
+		</div>
+
+		<div class="mobileph">
+			<a href="index.php"><img src="assets/images/plc-logo.png" class="logo png_img img-responsive" /></a>
+			<img src="assets/images/dse-name-p-plc.png" class="dsename png_img img-responsive" />
+			<!--img src="assets/images/mujib10years.png" class="img-responsive mUjibMobile" style="float: right;padding-bottom: 10px; width: 60%;"-->
+		</div>
+
+		<div class="Scroller">
+    		<div class="scroll-item">
+	        				  		<marquee id='mq2'  width='100%' height = '33' align='top' behavior = 'scroll' direction = 'left' onMouseOut=this.start(); onMouseOver=this.stop(); scrollamount='1' scrolldelay='10' truespeed bgcolor='#fffff4'>
+	        	          		<table border="0" cellpadding="0" cellspacing="0" width="100%" >
+					<tr>
+	          								<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=1JANATAMF" class='abhead' target='_top'>
+											1JANATAMF&nbsp;3.00&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=1STPRIMFMF" class='abhead' target='_top'>
+											1STPRIMFMF&nbsp;20.30&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.30&nbsp;&nbsp;&nbsp;&nbsp;-1.46%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=AAMRANET" class='abhead' target='_top'>
+											AAMRANET&nbsp;19.00&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.60&nbsp;&nbsp;&nbsp;&nbsp;3.26%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=AAMRATECH" class='abhead' target='_top'>
+											AAMRATECH&nbsp;14.90&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.68%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ABB1STMF" class='abhead' target='_top'>
+											ABB1STMF&nbsp;3.20&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="105" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ABBANK" class='abhead' target='_top'>
+											ABBANK&nbsp;4.90&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-2.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="100" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ACFL" class='abhead' target='_top'>
+											ACFL&nbsp;&nbsp;&nbsp;24.30&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;0.83%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="100" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ACI" class='abhead' target='_top'>
+											ACI&nbsp;&nbsp;&nbsp;189.40&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.00&nbsp;&nbsp;&nbsp;&nbsp;-0.53%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="135" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ACIFORMULA" class='abhead' target='_top'>
+											ACIFORMULA&nbsp;142.80&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ACMELAB" class='abhead' target='_top'>
+											ACMELAB&nbsp;80.10&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.60&nbsp;&nbsp;&nbsp;&nbsp;0.75%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="110" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ACMEPL" class='abhead' target='_top'>
+											ACMEPL&nbsp;24.40&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.40&nbsp;&nbsp;&nbsp;&nbsp;1.67%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ACTIVEFINE" class='abhead' target='_top'>
+											ACTIVEFINE&nbsp;7.40&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.30&nbsp;&nbsp;&nbsp;&nbsp;4.23%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="110" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ADNTEL" class='abhead' target='_top'>
+											ADNTEL&nbsp;68.70&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				1.50&nbsp;&nbsp;&nbsp;&nbsp;2.23%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="110" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ADVENT" class='abhead' target='_top'>
+											ADVENT&nbsp;15.50&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.40&nbsp;&nbsp;&nbsp;&nbsp;2.65%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="110" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=AFCAGRO" class='abhead' target='_top'>
+											AFCAGRO&nbsp;7.90&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;1.28%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=AFTABAUTO" class='abhead' target='_top'>
+											AFTABAUTO&nbsp;31.80&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.30&nbsp;&nbsp;&nbsp;&nbsp;0.95%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=AGNISYSL" class='abhead' target='_top'>
+											AGNISYSL&nbsp;30.10&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				1.20&nbsp;&nbsp;&nbsp;&nbsp;4.15%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=AGRANINS" class='abhead' target='_top'>
+											AGRANINS&nbsp;26.70&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.20&nbsp;&nbsp;&nbsp;&nbsp;-0.74%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=AIBL1STIMF" class='abhead' target='_top'>
+											AIBL1STIMF&nbsp;4.20&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="135" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=AIBLPBOND" class='abhead' target='_top'>
+											AIBLPBOND&nbsp;3842.00&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-200.50&nbsp;&nbsp;&nbsp;&nbsp;-4.96%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="95" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=AIL" class='abhead' target='_top'>
+											AIL&nbsp;&nbsp;&nbsp;34.30&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;0.59%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=AL-HAJTEX" class='abhead' target='_top'>
+											AL-HAJTEX&nbsp;107.10&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.50&nbsp;&nbsp;&nbsp;&nbsp;-1.38%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ALARABANK" class='abhead' target='_top'>
+											ALARABANK&nbsp;14.50&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="95" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ALIF" class='abhead' target='_top'>
+											ALIF&nbsp;&nbsp;&nbsp;5.50&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="110" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ALLTEX" class='abhead' target='_top'>
+											ALLTEX&nbsp;17.10&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.50&nbsp;&nbsp;&nbsp;&nbsp;3.01%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=AMANFEED" class='abhead' target='_top'>
+											AMANFEED&nbsp;35.10&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.60&nbsp;&nbsp;&nbsp;&nbsp;1.74%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=AMBEEPHA" class='abhead' target='_top'>
+											AMBEEPHA&nbsp;762.00&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.00&nbsp;&nbsp;&nbsp;&nbsp;-0.13%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="135" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=AMCL(PRAN)" class='abhead' target='_top'>
+											AMCL(PRAN)&nbsp;216.90&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.40&nbsp;&nbsp;&nbsp;&nbsp;-0.64%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ANLIMAYARN" class='abhead' target='_top'>
+											ANLIMAYARN&nbsp;34.30&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.50&nbsp;&nbsp;&nbsp;&nbsp;1.48%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ANWARGALV" class='abhead' target='_top'>
+											ANWARGALV&nbsp;116.70&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.09%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="95" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=AOL" class='abhead' target='_top'>
+											AOL&nbsp;&nbsp;&nbsp;18.00&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.60&nbsp;&nbsp;&nbsp;&nbsp;3.45%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=APEXFOODS" class='abhead' target='_top'>
+											APEXFOODS&nbsp;267.90&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.90&nbsp;&nbsp;&nbsp;&nbsp;-0.70%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=APEXFOOT" class='abhead' target='_top'>
+											APEXFOOT&nbsp;200.90&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.50&nbsp;&nbsp;&nbsp;&nbsp;0.25%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=APEXSPINN" class='abhead' target='_top'>
+											APEXSPINN&nbsp;332.40&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-22.00&nbsp;&nbsp;&nbsp;&nbsp;-6.21%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=APEXTANRY" class='abhead' target='_top'>
+											APEXTANRY&nbsp;100.70&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-2.20&nbsp;&nbsp;&nbsp;&nbsp;-2.14%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=APOLOISPAT" class='abhead' target='_top'>
+											APOLOISPAT&nbsp;3.50&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;6.06%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="135" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=APSCLBOND" class='abhead' target='_top'>
+											APSCLBOND&nbsp;1121.00&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-69.00&nbsp;&nbsp;&nbsp;&nbsp;-5.80%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ARAMIT" class='abhead' target='_top'>
+											ARAMIT&nbsp;191.00&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				2.10&nbsp;&nbsp;&nbsp;&nbsp;1.11%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ARAMITCEM" class='abhead' target='_top'>
+											ARAMITCEM&nbsp;12.60&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.80%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ARGONDENIM" class='abhead' target='_top'>
+											ARGONDENIM&nbsp;19.70&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ASIAINS" class='abhead' target='_top'>
+											ASIAINS&nbsp;42.00&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.30&nbsp;&nbsp;&nbsp;&nbsp;-3.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ASIAPACINS" class='abhead' target='_top'>
+											ASIAPACINS&nbsp;45.30&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.60&nbsp;&nbsp;&nbsp;&nbsp;-1.31%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="135" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ASIATICLAB" class='abhead' target='_top'>
+											ASIATICLAB&nbsp;123.50&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				2.80&nbsp;&nbsp;&nbsp;&nbsp;2.32%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ATLASBANG" class='abhead' target='_top'>
+											ATLASBANG&nbsp;69.00&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.30&nbsp;&nbsp;&nbsp;&nbsp;-0.43%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=AZIZPIPES" class='abhead' target='_top'>
+											AZIZPIPES&nbsp;78.70&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.70&nbsp;&nbsp;&nbsp;&nbsp;0.90%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BANGAS" class='abhead' target='_top'>
+											BANGAS&nbsp;134.10&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.70&nbsp;&nbsp;&nbsp;&nbsp;-0.52%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BANKASIA" class='abhead' target='_top'>
+											BANKASIA&nbsp;18.40&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-0.54%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BARKAPOWER" class='abhead' target='_top'>
+											BARKAPOWER&nbsp;8.70&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;2.35%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BATASHOE" class='abhead' target='_top'>
+											BATASHOE&nbsp;874.80&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				16.70&nbsp;&nbsp;&nbsp;&nbsp;1.95%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="110" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BATBC" class='abhead' target='_top'>
+											BATBC&nbsp;&nbsp;&nbsp;212.20&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.05%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BAYLEASING" class='abhead' target='_top'>
+											BAYLEASING&nbsp;4.70&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="95" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BBS" class='abhead' target='_top'>
+											BBS&nbsp;&nbsp;&nbsp;16.10&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				1.30&nbsp;&nbsp;&nbsp;&nbsp;8.78%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BBSCABLES" class='abhead' target='_top'>
+											BBSCABLES&nbsp;24.80&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.80&nbsp;&nbsp;&nbsp;&nbsp;3.33%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BDAUTOCA" class='abhead' target='_top'>
+											BDAUTOCA&nbsp;216.30&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-2.40&nbsp;&nbsp;&nbsp;&nbsp;-1.10%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="105" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BDCOM" class='abhead' target='_top'>
+											BDCOM&nbsp;&nbsp;&nbsp;33.00&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				2.90&nbsp;&nbsp;&nbsp;&nbsp;9.63%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BDFINANCE" class='abhead' target='_top'>
+											BDFINANCE&nbsp;13.50&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.75%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BDLAMPS" class='abhead' target='_top'>
+											BDLAMPS&nbsp;175.20&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.90&nbsp;&nbsp;&nbsp;&nbsp;-1.07%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="110" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BDTHAI" class='abhead' target='_top'>
+											BDTHAI&nbsp;20.30&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-0.49%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BDTHAIFOOD" class='abhead' target='_top'>
+											BDTHAIFOOD&nbsp;29.20&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.70&nbsp;&nbsp;&nbsp;&nbsp;-5.50%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BDWELDING" class='abhead' target='_top'>
+											BDWELDING&nbsp;15.80&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-0.63%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BEACHHATCH" class='abhead' target='_top'>
+											BEACHHATCH&nbsp;34.00&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				1.10&nbsp;&nbsp;&nbsp;&nbsp;3.34%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="135" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BEACONPHAR" class='abhead' target='_top'>
+											BEACONPHAR&nbsp;108.50&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.20&nbsp;&nbsp;&nbsp;&nbsp;-0.18%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BENGALWTL" class='abhead' target='_top'>
+											BENGALWTL&nbsp;25.20&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.40&nbsp;&nbsp;&nbsp;&nbsp;1.61%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="135" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BERGERPBL" class='abhead' target='_top'>
+											BERGERPBL&nbsp;1418.00&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				2.60&nbsp;&nbsp;&nbsp;&nbsp;0.18%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BESTHLDNG" class='abhead' target='_top'>
+											BESTHLDNG&nbsp;14.80&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-0.67%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BEXGSUKUK" class='abhead' target='_top'>
+											BEXGSUKUK&nbsp;72.50&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.50&nbsp;&nbsp;&nbsp;&nbsp;0.69%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BEXIMCO" class='abhead' target='_top'>
+											BEXIMCO&nbsp;52.80&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-5.80&nbsp;&nbsp;&nbsp;&nbsp;-9.90%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="100" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BGIC" class='abhead' target='_top'>
+											BGIC&nbsp;&nbsp;&nbsp;39.80&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.50&nbsp;&nbsp;&nbsp;&nbsp;-1.24%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="95" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BIFC" class='abhead' target='_top'>
+											BIFC&nbsp;&nbsp;&nbsp;4.40&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-2.22%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="110" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BNICL" class='abhead' target='_top'>
+											BNICL&nbsp;&nbsp;&nbsp;103.90&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-4.40&nbsp;&nbsp;&nbsp;&nbsp;-4.06%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="100" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BPML" class='abhead' target='_top'>
+											BPML&nbsp;&nbsp;&nbsp;28.60&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.20&nbsp;&nbsp;&nbsp;&nbsp;-0.69%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="100" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BPPL" class='abhead' target='_top'>
+											BPPL&nbsp;&nbsp;&nbsp;20.60&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.49%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BRACBANK" class='abhead' target='_top'>
+											BRACBANK&nbsp;65.60&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.50&nbsp;&nbsp;&nbsp;&nbsp;-0.76%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="100" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BSC" class='abhead' target='_top'>
+											BSC&nbsp;&nbsp;&nbsp;107.30&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.70&nbsp;&nbsp;&nbsp;&nbsp;-0.65%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BSCPLC" class='abhead' target='_top'>
+											BSCPLC&nbsp;147.30&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;0.14%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BSRMLTD" class='abhead' target='_top'>
+											BSRMLTD&nbsp;92.90&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.11%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BSRMSTEEL" class='abhead' target='_top'>
+											BSRMSTEEL&nbsp;79.00&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.90&nbsp;&nbsp;&nbsp;&nbsp;1.15%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BXPHARMA" class='abhead' target='_top'>
+											BXPHARMA&nbsp;134.70&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				2.40&nbsp;&nbsp;&nbsp;&nbsp;1.81%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=CAPITECGBF" class='abhead' target='_top'>
+											CAPITECGBF&nbsp;7.50&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=CAPMBDBLMF" class='abhead' target='_top'>
+											CAPMBDBLMF&nbsp;9.90&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=CAPMIBBLMF" class='abhead' target='_top'>
+											CAPMIBBLMF&nbsp;9.60&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;1.05%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=CENTRALINS" class='abhead' target='_top'>
+											CENTRALINS&nbsp;43.10&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.70&nbsp;&nbsp;&nbsp;&nbsp;-1.60%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=CENTRALPHL" class='abhead' target='_top'>
+											CENTRALPHL&nbsp;9.60&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.30&nbsp;&nbsp;&nbsp;&nbsp;3.23%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=CITYBANK" class='abhead' target='_top'>
+											CITYBANK&nbsp;30.50&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="135" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=CITYGENINS" class='abhead' target='_top'>
+											CITYGENINS&nbsp;106.80&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.40&nbsp;&nbsp;&nbsp;&nbsp;0.38%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="105" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=CLICL" class='abhead' target='_top'>
+											CLICL&nbsp;&nbsp;&nbsp;54.20&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.70&nbsp;&nbsp;&nbsp;&nbsp;-3.04%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="105" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=CNATEX" class='abhead' target='_top'>
+											CNATEX&nbsp;3.40&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;6.25%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=CONFIDCEM" class='abhead' target='_top'>
+											CONFIDCEM&nbsp;63.80&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.40&nbsp;&nbsp;&nbsp;&nbsp;-0.62%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=CONTININS" class='abhead' target='_top'>
+											CONTININS&nbsp;33.00&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=COPPERTECH" class='abhead' target='_top'>
+											COPPERTECH&nbsp;28.20&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.80&nbsp;&nbsp;&nbsp;&nbsp;2.92%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=CROWNCEMNT" class='abhead' target='_top'>
+											CROWNCEMNT&nbsp;55.10&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=CRYSTALINS" class='abhead' target='_top'>
+											CRYSTALINS&nbsp;71.90&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.40&nbsp;&nbsp;&nbsp;&nbsp;-1.91%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=CVOPRL" class='abhead' target='_top'>
+											CVOPRL&nbsp;166.30&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-0.06%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=DACCADYE" class='abhead' target='_top'>
+											DACCADYE&nbsp;17.50&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="135" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=DAFODILCOM" class='abhead' target='_top'>
+											DAFODILCOM&nbsp;159.80&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				2.20&nbsp;&nbsp;&nbsp;&nbsp;1.40%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="95" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=DBH" class='abhead' target='_top'>
+											DBH&nbsp;&nbsp;&nbsp;41.00&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.30&nbsp;&nbsp;&nbsp;&nbsp;-0.73%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=DBH1STMF" class='abhead' target='_top'>
+											DBH1STMF&nbsp;4.70&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=DELTALIFE" class='abhead' target='_top'>
+											DELTALIFE&nbsp;80.60&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.40&nbsp;&nbsp;&nbsp;&nbsp;-1.71%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=DELTASPINN" class='abhead' target='_top'>
+											DELTASPINN&nbsp;6.90&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;1.47%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="105" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=DESCO" class='abhead' target='_top'>
+											DESCO&nbsp;&nbsp;&nbsp;23.90&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.40&nbsp;&nbsp;&nbsp;&nbsp;-1.65%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=DESHBANDHU" class='abhead' target='_top'>
+											DESHBANDHU&nbsp;21.70&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.46%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="100" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=DGIC" class='abhead' target='_top'>
+											DGIC&nbsp;&nbsp;&nbsp;29.10&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.40&nbsp;&nbsp;&nbsp;&nbsp;-1.36%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=DHAKABANK" class='abhead' target='_top'>
+											DHAKABANK&nbsp;12.00&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=DOMINAGE" class='abhead' target='_top'>
+											DOMINAGE&nbsp;79.90&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-0.12%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=DOREENPWR" class='abhead' target='_top'>
+											DOREENPWR&nbsp;31.80&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.60&nbsp;&nbsp;&nbsp;&nbsp;-1.85%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=DSHGARME" class='abhead' target='_top'>
+											DSHGARME&nbsp;143.00&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-3.90&nbsp;&nbsp;&nbsp;&nbsp;-2.65%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="100" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=DSSL" class='abhead' target='_top'>
+											DSSL&nbsp;&nbsp;&nbsp;11.10&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-0.89%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="135" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=DULAMIACOT" class='abhead' target='_top'>
+											DULAMIACOT&nbsp;181.90&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.60&nbsp;&nbsp;&nbsp;&nbsp;-0.87%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=DUTCHBANGL" class='abhead' target='_top'>
+											DUTCHBANGL&nbsp;43.10&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;0.47%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=EASTERNINS" class='abhead' target='_top'>
+											EASTERNINS&nbsp;59.10&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-2.60&nbsp;&nbsp;&nbsp;&nbsp;-4.21%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=EASTLAND" class='abhead' target='_top'>
+											EASTLAND&nbsp;26.00&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-0.38%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="135" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=EASTRNLUB" class='abhead' target='_top'>
+											EASTRNLUB&nbsp;1832.70&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.20&nbsp;&nbsp;&nbsp;&nbsp;-0.07%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="95" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=EBL" class='abhead' target='_top'>
+											EBL&nbsp;&nbsp;&nbsp;24.80&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=EBL1STMF" class='abhead' target='_top'>
+											EBL1STMF&nbsp;3.80&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=EBLNRBMF" class='abhead' target='_top'>
+											EBLNRBMF&nbsp;3.10&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ECABLES" class='abhead' target='_top'>
+											ECABLES&nbsp;124.70&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				2.00&nbsp;&nbsp;&nbsp;&nbsp;1.63%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="100" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=EGEN" class='abhead' target='_top'>
+											EGEN&nbsp;&nbsp;&nbsp;26.90&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				1.00&nbsp;&nbsp;&nbsp;&nbsp;3.86%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="95" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=EHL" class='abhead' target='_top'>
+											EHL&nbsp;&nbsp;&nbsp;88.10&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.20&nbsp;&nbsp;&nbsp;&nbsp;-0.23%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="95" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=EIL" class='abhead' target='_top'>
+											EIL&nbsp;&nbsp;&nbsp;30.30&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.40&nbsp;&nbsp;&nbsp;&nbsp;-1.30%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=EMERALDOIL" class='abhead' target='_top'>
+											EMERALDOIL&nbsp;23.20&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.50&nbsp;&nbsp;&nbsp;&nbsp;-2.11%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ENVOYTEX" class='abhead' target='_top'>
+											ENVOYTEX&nbsp;52.10&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.19%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="100" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=EPGL" class='abhead' target='_top'>
+											EPGL&nbsp;&nbsp;&nbsp;20.60&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ESQUIRENIT" class='abhead' target='_top'>
+											ESQUIRENIT&nbsp;24.80&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.40%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="95" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ETL" class='abhead' target='_top'>
+											ETL&nbsp;&nbsp;&nbsp;13.30&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.20&nbsp;&nbsp;&nbsp;&nbsp;-1.48%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=EXIM1STMF" class='abhead' target='_top'>
+											EXIM1STMF&nbsp;3.50&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=FAMILYTEX" class='abhead' target='_top'>
+											FAMILYTEX&nbsp;2.80&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=FARCHEM" class='abhead' target='_top'>
+											FARCHEM&nbsp;19.20&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;1.05%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=FAREASTFIN" class='abhead' target='_top'>
+											FAREASTFIN&nbsp;1.30&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-7.14%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=FAREASTLIF" class='abhead' target='_top'>
+											FAREASTLIF&nbsp;24.20&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;0.83%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="105" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=FASFIN" class='abhead' target='_top'>
+											FASFIN&nbsp;1.30&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-7.14%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="100" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=FBFIF" class='abhead' target='_top'>
+											FBFIF&nbsp;&nbsp;&nbsp;3.10&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=FEDERALINS" class='abhead' target='_top'>
+											FEDERALINS&nbsp;28.00&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.70&nbsp;&nbsp;&nbsp;&nbsp;-5.72%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="110" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=FEKDIL" class='abhead' target='_top'>
+											FEKDIL&nbsp;17.10&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.20&nbsp;&nbsp;&nbsp;&nbsp;-1.16%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=FINEFOODS" class='abhead' target='_top'>
+											FINEFOODS&nbsp;543.60&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.00&nbsp;&nbsp;&nbsp;&nbsp;-0.18%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=FIRSTFIN" class='abhead' target='_top'>
+											FIRSTFIN&nbsp;4.30&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=FORTUNE" class='abhead' target='_top'>
+											FORTUNE&nbsp;15.90&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;1.27%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=FUWANGCER" class='abhead' target='_top'>
+											FUWANGCER&nbsp;15.90&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.40&nbsp;&nbsp;&nbsp;&nbsp;2.58%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=FUWANGFOOD" class='abhead' target='_top'>
+											FUWANGFOOD&nbsp;11.50&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.50&nbsp;&nbsp;&nbsp;&nbsp;4.55%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=GBBPOWER" class='abhead' target='_top'>
+											GBBPOWER&nbsp;8.80&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=GEMINISEA" class='abhead' target='_top'>
+											GEMINISEA&nbsp;117.00&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.50&nbsp;&nbsp;&nbsp;&nbsp;-0.43%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=GENEXIL" class='abhead' target='_top'>
+											GENEXIL&nbsp;37.20&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				1.80&nbsp;&nbsp;&nbsp;&nbsp;5.08%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="110" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=GENNEXT" class='abhead' target='_top'>
+											GENNEXT&nbsp;3.30&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;6.45%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="105" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=GHAIL" class='abhead' target='_top'>
+											GHAIL&nbsp;&nbsp;&nbsp;15.60&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.60&nbsp;&nbsp;&nbsp;&nbsp;4.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="100" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=GHCL" class='abhead' target='_top'>
+											GHCL&nbsp;&nbsp;&nbsp;20.80&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;0.97%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="110" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=GLDNJMF" class='abhead' target='_top'>
+											GLDNJMF&nbsp;6.50&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-1.52%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=GLOBALINS" class='abhead' target='_top'>
+											GLOBALINS&nbsp;37.60&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.50&nbsp;&nbsp;&nbsp;&nbsp;-1.31%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=GOLDENSON" class='abhead' target='_top'>
+											GOLDENSON&nbsp;17.20&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.50&nbsp;&nbsp;&nbsp;&nbsp;2.99%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="95" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=GP" class='abhead' target='_top'>
+											GP&nbsp;&nbsp;&nbsp;251.50&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.90&nbsp;&nbsp;&nbsp;&nbsp;0.36%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=GPHISPAT" class='abhead' target='_top'>
+											GPHISPAT&nbsp;18.00&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;1.12%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=GQBALLPEN" class='abhead' target='_top'>
+											GQBALLPEN&nbsp;634.50&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-6.60&nbsp;&nbsp;&nbsp;&nbsp;-1.03%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=GRAMEENS2" class='abhead' target='_top'>
+											GRAMEENS2&nbsp;12.80&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.30&nbsp;&nbsp;&nbsp;&nbsp;2.40%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=GREENDELMF" class='abhead' target='_top'>
+											GREENDELMF&nbsp;3.50&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;2.94%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=GREENDELT" class='abhead' target='_top'>
+											GREENDELT&nbsp;66.50&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.10&nbsp;&nbsp;&nbsp;&nbsp;-1.63%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=GSPFINANCE" class='abhead' target='_top'>
+											GSPFINANCE&nbsp;3.70&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-2.63%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=HAKKANIPUL" class='abhead' target='_top'>
+											HAKKANIPUL&nbsp;79.20&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.40&nbsp;&nbsp;&nbsp;&nbsp;0.51%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="105" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=HAMI" class='abhead' target='_top'>
+											HAMI&nbsp;&nbsp;&nbsp;156.60&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-4.50&nbsp;&nbsp;&nbsp;&nbsp;-2.79%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="135" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=HEIDELBCEM" class='abhead' target='_top'>
+											HEIDELBCEM&nbsp;227.40&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-2.80&nbsp;&nbsp;&nbsp;&nbsp;-1.22%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="95" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=HFL" class='abhead' target='_top'>
+											HFL&nbsp;&nbsp;&nbsp;16.00&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				1.40&nbsp;&nbsp;&nbsp;&nbsp;9.59%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="105" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=HRTEX" class='abhead' target='_top'>
+											HRTEX&nbsp;&nbsp;&nbsp;21.40&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.30&nbsp;&nbsp;&nbsp;&nbsp;1.42%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=HWAWELLTEX" class='abhead' target='_top'>
+											HWAWELLTEX&nbsp;45.10&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.30&nbsp;&nbsp;&nbsp;&nbsp;0.67%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=IBBLPBOND" class='abhead' target='_top'>
+											IBBLPBOND&nbsp;675.00&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				12.00&nbsp;&nbsp;&nbsp;&nbsp;1.81%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=IBNSINA" class='abhead' target='_top'>
+											IBNSINA&nbsp;314.00&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.03%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="95" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=IBP" class='abhead' target='_top'>
+											IBP&nbsp;&nbsp;&nbsp;16.00&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.50&nbsp;&nbsp;&nbsp;&nbsp;3.23%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="95" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ICB" class='abhead' target='_top'>
+											ICB&nbsp;&nbsp;&nbsp;44.00&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.60&nbsp;&nbsp;&nbsp;&nbsp;1.38%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ICB3RDNRB" class='abhead' target='_top'>
+											ICB3RDNRB&nbsp;4.60&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-2.13%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ICBAGRANI1" class='abhead' target='_top'>
+											ICBAGRANI1&nbsp;6.80&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ICBAMCL2ND" class='abhead' target='_top'>
+											ICBAMCL2ND&nbsp;6.30&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;1.61%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ICBEPMF1S1" class='abhead' target='_top'>
+											ICBEPMF1S1&nbsp;6.30&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.30&nbsp;&nbsp;&nbsp;&nbsp;-4.55%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ICBIBANK" class='abhead' target='_top'>
+											ICBIBANK&nbsp;2.90&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ICBSONALI1" class='abhead' target='_top'>
+											ICBSONALI1&nbsp;5.00&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="105" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ICICL" class='abhead' target='_top'>
+											ICICL&nbsp;&nbsp;&nbsp;29.20&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-0.34%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="100" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=IDLC" class='abhead' target='_top'>
+											IDLC&nbsp;&nbsp;&nbsp;40.80&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.30&nbsp;&nbsp;&nbsp;&nbsp;-0.73%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=IFADAUTOS" class='abhead' target='_top'>
+											IFADAUTOS&nbsp;24.70&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.30&nbsp;&nbsp;&nbsp;&nbsp;1.23%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="95" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=IFIC" class='abhead' target='_top'>
+											IFIC&nbsp;&nbsp;&nbsp;5.00&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=IFIC1STMF" class='abhead' target='_top'>
+											IFIC1STMF&nbsp;3.50&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=IFILISLMF1" class='abhead' target='_top'>
+											IFILISLMF1&nbsp;4.10&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-2.38%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="100" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ILFSL" class='abhead' target='_top'>
+											ILFSL&nbsp;&nbsp;&nbsp;1.30&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-7.14%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=INDEXAGRO" class='abhead' target='_top'>
+											INDEXAGRO&nbsp;72.00&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-0.14%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="110" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=INTECH" class='abhead' target='_top'>
+											INTECH&nbsp;36.50&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				1.20&nbsp;&nbsp;&nbsp;&nbsp;3.40%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=INTRACO" class='abhead' target='_top'>
+											INTRACO&nbsp;20.40&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;0.99%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="100" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=IPDC" class='abhead' target='_top'>
+											IPDC&nbsp;&nbsp;&nbsp;28.80&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.50&nbsp;&nbsp;&nbsp;&nbsp;1.77%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ISLAMIBANK" class='abhead' target='_top'>
+											ISLAMIBANK&nbsp;33.80&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.30&nbsp;&nbsp;&nbsp;&nbsp;-0.88%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ISLAMICFIN" class='abhead' target='_top'>
+											ISLAMICFIN&nbsp;11.10&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.91%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ISLAMIINS" class='abhead' target='_top'>
+											ISLAMIINS&nbsp;58.80&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				3.80&nbsp;&nbsp;&nbsp;&nbsp;6.91%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="110" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ISNLTD" class='abhead' target='_top'>
+											ISNLTD&nbsp;63.20&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				2.30&nbsp;&nbsp;&nbsp;&nbsp;3.78%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="95" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ITC" class='abhead' target='_top'>
+											ITC&nbsp;&nbsp;&nbsp;42.70&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				1.40&nbsp;&nbsp;&nbsp;&nbsp;3.39%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=JAMUNABANK" class='abhead' target='_top'>
+											JAMUNABANK&nbsp;23.90&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.42%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=JAMUNAOIL" class='abhead' target='_top'>
+											JAMUNAOIL&nbsp;176.50&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.80&nbsp;&nbsp;&nbsp;&nbsp;0.46%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=JANATAINS" class='abhead' target='_top'>
+											JANATAINS&nbsp;35.10&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.30&nbsp;&nbsp;&nbsp;&nbsp;-0.85%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="105" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=JHRML" class='abhead' target='_top'>
+											JHRML&nbsp;&nbsp;&nbsp;50.50&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.20%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=JMISMDL" class='abhead' target='_top'>
+											JMISMDL&nbsp;128.10&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				1.10&nbsp;&nbsp;&nbsp;&nbsp;0.87%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=JUTESPINN" class='abhead' target='_top'>
+											JUTESPINN&nbsp;208.20&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.30&nbsp;&nbsp;&nbsp;&nbsp;-0.14%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=KARNAPHULI" class='abhead' target='_top'>
+											KARNAPHULI&nbsp;37.20&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.60&nbsp;&nbsp;&nbsp;&nbsp;-1.59%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=KAY&QUE" class='abhead' target='_top'>
+											KAY&QUE&nbsp;431.70&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-6.80&nbsp;&nbsp;&nbsp;&nbsp;-1.55%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=KBPPWBIL" class='abhead' target='_top'>
+											KBPPWBIL&nbsp;47.30&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.60&nbsp;&nbsp;&nbsp;&nbsp;1.28%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=KDSALTD" class='abhead' target='_top'>
+											KDSALTD&nbsp;48.70&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.30&nbsp;&nbsp;&nbsp;&nbsp;-0.61%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=KEYACOSMET" class='abhead' target='_top'>
+											KEYACOSMET&nbsp;5.00&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;4.17%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=KOHINOOR" class='abhead' target='_top'>
+											KOHINOOR&nbsp;502.20&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-5.80&nbsp;&nbsp;&nbsp;&nbsp;-1.14%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="100" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=KPCL" class='abhead' target='_top'>
+											KPCL&nbsp;&nbsp;&nbsp;11.00&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.92%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="100" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=KPPL" class='abhead' target='_top'>
+											KPPL&nbsp;&nbsp;&nbsp;15.80&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="95" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=KTL" class='abhead' target='_top'>
+											KTL&nbsp;&nbsp;&nbsp;10.60&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;1.92%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=LANKABAFIN" class='abhead' target='_top'>
+											LANKABAFIN&nbsp;16.50&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.20&nbsp;&nbsp;&nbsp;&nbsp;-1.20%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=LEGACYFOOT" class='abhead' target='_top'>
+											LEGACYFOOT&nbsp;67.80&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.50&nbsp;&nbsp;&nbsp;&nbsp;-0.73%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="95" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=LHB" class='abhead' target='_top'>
+											LHB&nbsp;&nbsp;&nbsp;54.40&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.18%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=LIBRAINFU" class='abhead' target='_top'>
+											LIBRAINFU&nbsp;639.80&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-6.50&nbsp;&nbsp;&nbsp;&nbsp;-1.01%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=LINDEBD" class='abhead' target='_top'>
+											LINDEBD&nbsp;699.10&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				2.00&nbsp;&nbsp;&nbsp;&nbsp;0.29%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=LOVELLO" class='abhead' target='_top'>
+											LOVELLO&nbsp;71.20&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.14%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="105" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=LRBDL" class='abhead' target='_top'>
+											LRBDL&nbsp;&nbsp;&nbsp;11.90&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;1.71%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=LRGLOBMF1" class='abhead' target='_top'>
+											LRGLOBMF1&nbsp;3.40&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;6.25%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MAGURAPLEX" class='abhead' target='_top'>
+											MAGURAPLEX&nbsp;87.40&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;0.23%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MAKSONSPIN" class='abhead' target='_top'>
+											MAKSONSPIN&nbsp;6.10&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;1.67%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MALEKSPIN" class='abhead' target='_top'>
+											MALEKSPIN&nbsp;31.10&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.60&nbsp;&nbsp;&nbsp;&nbsp;1.97%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MARICO" class='abhead' target='_top'>
+											MARICO&nbsp;2748.20&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				3.30&nbsp;&nbsp;&nbsp;&nbsp;0.12%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MATINSPINN" class='abhead' target='_top'>
+											MATINSPINN&nbsp;52.10&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.50&nbsp;&nbsp;&nbsp;&nbsp;0.97%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MBL1STMF" class='abhead' target='_top'>
+											MBL1STMF&nbsp;3.90&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MEGCONMILK" class='abhead' target='_top'>
+											MEGCONMILK&nbsp;40.30&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				2.10&nbsp;&nbsp;&nbsp;&nbsp;5.50%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MEGHNACEM" class='abhead' target='_top'>
+											MEGHNACEM&nbsp;32.00&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-0.31%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MEGHNAINS" class='abhead' target='_top'>
+											MEGHNAINS&nbsp;34.40&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.60&nbsp;&nbsp;&nbsp;&nbsp;-1.71%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MEGHNALIFE" class='abhead' target='_top'>
+											MEGHNALIFE&nbsp;60.50&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.70&nbsp;&nbsp;&nbsp;&nbsp;-1.14%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MEGHNAPET" class='abhead' target='_top'>
+											MEGHNAPET&nbsp;77.80&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;0.26%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MERCANBANK" class='abhead' target='_top'>
+											MERCANBANK&nbsp;7.50&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;2.74%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MERCINS" class='abhead' target='_top'>
+											MERCINS&nbsp;39.00&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.80&nbsp;&nbsp;&nbsp;&nbsp;2.09%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=METROSPIN" class='abhead' target='_top'>
+											METROSPIN&nbsp;9.60&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;1.05%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="105" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MHSML" class='abhead' target='_top'>
+											MHSML&nbsp;&nbsp;&nbsp;23.30&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				1.00&nbsp;&nbsp;&nbsp;&nbsp;4.48%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MIDASFIN" class='abhead' target='_top'>
+											MIDASFIN&nbsp;6.20&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.50&nbsp;&nbsp;&nbsp;&nbsp;8.77%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MIDLANDBNK" class='abhead' target='_top'>
+											MIDLANDBNK&nbsp;16.50&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;1.23%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MIRACLEIND" class='abhead' target='_top'>
+											MIRACLEIND&nbsp;28.10&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.36%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MIRAKHTER" class='abhead' target='_top'>
+											MIRAKHTER&nbsp;41.80&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.50&nbsp;&nbsp;&nbsp;&nbsp;1.21%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MITHUNKNIT" class='abhead' target='_top'>
+											MITHUNKNIT&nbsp;15.50&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="105" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MJLBD" class='abhead' target='_top'>
+											MJLBD&nbsp;&nbsp;&nbsp;90.50&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.40&nbsp;&nbsp;&nbsp;&nbsp;-1.52%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MLDYEING" class='abhead' target='_top'>
+											MLDYEING&nbsp;11.40&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.40&nbsp;&nbsp;&nbsp;&nbsp;3.64%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MONNOAGML" class='abhead' target='_top'>
+											MONNOAGML&nbsp;347.00&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-3.90&nbsp;&nbsp;&nbsp;&nbsp;-1.11%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MONNOCERA" class='abhead' target='_top'>
+											MONNOCERA&nbsp;95.90&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;0.21%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MONNOFABR" class='abhead' target='_top'>
+											MONNOFABR&nbsp;23.20&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;0.87%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MONOSPOOL" class='abhead' target='_top'>
+											MONOSPOOL&nbsp;109.30&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				1.00&nbsp;&nbsp;&nbsp;&nbsp;0.92%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="135" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MPETROLEUM" class='abhead' target='_top'>
+											MPETROLEUM&nbsp;209.00&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="95" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MTB" class='abhead' target='_top'>
+											MTB&nbsp;&nbsp;&nbsp;13.90&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.30&nbsp;&nbsp;&nbsp;&nbsp;2.21%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=NAHEEACP" class='abhead' target='_top'>
+											NAHEEACP&nbsp;35.90&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.60&nbsp;&nbsp;&nbsp;&nbsp;1.70%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="135" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=NATLIFEINS" class='abhead' target='_top'>
+											NATLIFEINS&nbsp;104.10&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.60&nbsp;&nbsp;&nbsp;&nbsp;0.58%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=NAVANACNG" class='abhead' target='_top'>
+											NAVANACNG&nbsp;22.00&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.30&nbsp;&nbsp;&nbsp;&nbsp;1.38%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=NAVANAPHAR" class='abhead' target='_top'>
+											NAVANAPHAR&nbsp;70.90&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.40&nbsp;&nbsp;&nbsp;&nbsp;0.57%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="90" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=NBL" class='abhead' target='_top'>
+											NBL&nbsp;&nbsp;&nbsp;4.10&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=NCCBANK" class='abhead' target='_top'>
+											NCCBANK&nbsp;16.60&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=NCCBLMF1" class='abhead' target='_top'>
+											NCCBLMF1&nbsp;4.30&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;2.38%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="110" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=NEWLINE" class='abhead' target='_top'>
+											NEWLINE&nbsp;6.10&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.50&nbsp;&nbsp;&nbsp;&nbsp;8.93%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="100" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=NFML" class='abhead' target='_top'>
+											NFML&nbsp;&nbsp;&nbsp;20.90&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				1.90&nbsp;&nbsp;&nbsp;&nbsp;10.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="105" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=NHFIL" class='abhead' target='_top'>
+											NHFIL&nbsp;&nbsp;&nbsp;27.60&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-0.36%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=NITOLINS" class='abhead' target='_top'>
+											NITOLINS&nbsp;34.60&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.30&nbsp;&nbsp;&nbsp;&nbsp;-0.86%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=NORTHERN" class='abhead' target='_top'>
+											NORTHERN&nbsp;111.30&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				1.30&nbsp;&nbsp;&nbsp;&nbsp;1.18%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=NORTHRNINS" class='abhead' target='_top'>
+											NORTHRNINS&nbsp;41.30&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.20&nbsp;&nbsp;&nbsp;&nbsp;-0.48%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=NPOLYMER" class='abhead' target='_top'>
+											NPOLYMER&nbsp;33.40&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.30%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=NRBCBANK" class='abhead' target='_top'>
+											NRBCBANK&nbsp;7.40&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=NTLTUBES" class='abhead' target='_top'>
+											NTLTUBES&nbsp;66.00&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.50&nbsp;&nbsp;&nbsp;&nbsp;-0.75%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="105" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=NURANI" class='abhead' target='_top'>
+											NURANI&nbsp;3.20&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;3.23%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="90" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=OAL" class='abhead' target='_top'>
+											OAL&nbsp;&nbsp;&nbsp;6.70&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.40&nbsp;&nbsp;&nbsp;&nbsp;6.35%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="105" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=OIMEX" class='abhead' target='_top'>
+											OIMEX&nbsp;&nbsp;&nbsp;16.10&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.63%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=OLYMPIC" class='abhead' target='_top'>
+											OLYMPIC&nbsp;149.40&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				1.10&nbsp;&nbsp;&nbsp;&nbsp;0.74%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ONEBANKPLC" class='abhead' target='_top'>
+											ONEBANKPLC&nbsp;8.20&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ORIONINFU" class='abhead' target='_top'>
+											ORIONINFU&nbsp;315.20&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.50&nbsp;&nbsp;&nbsp;&nbsp;-0.47%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ORIONPHARM" class='abhead' target='_top'>
+											ORIONPHARM&nbsp;28.90&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-0.34%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PADMALIFE" class='abhead' target='_top'>
+											PADMALIFE&nbsp;19.50&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PADMAOIL" class='abhead' target='_top'>
+											PADMAOIL&nbsp;184.40&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;0.11%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PARAMOUNT" class='abhead' target='_top'>
+											PARAMOUNT&nbsp;60.80&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.60&nbsp;&nbsp;&nbsp;&nbsp;-2.56%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="90" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PDL" class='abhead' target='_top'>
+											PDL&nbsp;&nbsp;&nbsp;6.20&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.50&nbsp;&nbsp;&nbsp;&nbsp;8.77%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PENINSULA" class='abhead' target='_top'>
+											PENINSULA&nbsp;23.20&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.43%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PEOPLESINS" class='abhead' target='_top'>
+											PEOPLESINS&nbsp;58.50&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.60&nbsp;&nbsp;&nbsp;&nbsp;-2.66%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="110" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PF1STMF" class='abhead' target='_top'>
+											PF1STMF&nbsp;8.60&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;2.38%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PHARMAID" class='abhead' target='_top'>
+											PHARMAID&nbsp;567.80&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-3.60&nbsp;&nbsp;&nbsp;&nbsp;-0.63%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PHENIXINS" class='abhead' target='_top'>
+											PHENIXINS&nbsp;42.90&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.40&nbsp;&nbsp;&nbsp;&nbsp;-0.92%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PHOENIXFIN" class='abhead' target='_top'>
+											PHOENIXFIN&nbsp;3.80&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-2.56%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="105" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PHPMF1" class='abhead' target='_top'>
+											PHPMF1&nbsp;3.10&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PIONEERINS" class='abhead' target='_top'>
+											PIONEERINS&nbsp;67.50&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.40&nbsp;&nbsp;&nbsp;&nbsp;-0.59%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="100" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PLFSL" class='abhead' target='_top'>
+											PLFSL&nbsp;&nbsp;&nbsp;1.40&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=POPULAR1MF" class='abhead' target='_top'>
+											POPULAR1MF&nbsp;3.10&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=POPULARLIF" class='abhead' target='_top'>
+											POPULARLIF&nbsp;62.10&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.70&nbsp;&nbsp;&nbsp;&nbsp;-1.11%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=POWERGRID" class='abhead' target='_top'>
+											POWERGRID&nbsp;37.90&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.40&nbsp;&nbsp;&nbsp;&nbsp;-1.04%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PRAGATIINS" class='abhead' target='_top'>
+											PRAGATIINS&nbsp;74.10&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.90&nbsp;&nbsp;&nbsp;&nbsp;-1.20%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="135" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PRAGATILIF" class='abhead' target='_top'>
+											PRAGATILIF&nbsp;184.40&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.40&nbsp;&nbsp;&nbsp;&nbsp;-0.75%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PREMIERBAN" class='abhead' target='_top'>
+											PREMIERBAN&nbsp;4.50&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;2.27%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PREMIERCEM" class='abhead' target='_top'>
+											PREMIERCEM&nbsp;48.40&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				1.00&nbsp;&nbsp;&nbsp;&nbsp;2.11%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PREMIERLEA" class='abhead' target='_top'>
+											PREMIERLEA&nbsp;2.30&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.20&nbsp;&nbsp;&nbsp;&nbsp;-8.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PRIME1ICBA" class='abhead' target='_top'>
+											PRIME1ICBA&nbsp;4.70&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PRIMEBANK" class='abhead' target='_top'>
+											PRIMEBANK&nbsp;30.30&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;0.66%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PRIMEFIN" class='abhead' target='_top'>
+											PRIMEFIN&nbsp;3.20&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-3.03%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PRIMEINSUR" class='abhead' target='_top'>
+											PRIMEINSUR&nbsp;41.90&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.20&nbsp;&nbsp;&nbsp;&nbsp;-0.48%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PRIMELIFE" class='abhead' target='_top'>
+											PRIMELIFE&nbsp;44.40&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.30&nbsp;&nbsp;&nbsp;&nbsp;-0.67%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PRIMETEX" class='abhead' target='_top'>
+											PRIMETEX&nbsp;18.70&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				1.70&nbsp;&nbsp;&nbsp;&nbsp;10.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PROGRESLIF" class='abhead' target='_top'>
+											PROGRESLIF&nbsp;44.50&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.23%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PROVATIINS" class='abhead' target='_top'>
+											PROVATIINS&nbsp;54.80&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.50&nbsp;&nbsp;&nbsp;&nbsp;0.92%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="95" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PTL" class='abhead' target='_top'>
+											PTL&nbsp;&nbsp;&nbsp;63.80&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				1.00&nbsp;&nbsp;&nbsp;&nbsp;1.59%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PUBALIBANK" class='abhead' target='_top'>
+											PUBALIBANK&nbsp;36.90&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.40&nbsp;&nbsp;&nbsp;&nbsp;-1.07%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PURABIGEN" class='abhead' target='_top'>
+											PURABIGEN&nbsp;31.70&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.60&nbsp;&nbsp;&nbsp;&nbsp;-1.86%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=QUASEMIND" class='abhead' target='_top'>
+											QUASEMIND&nbsp;43.70&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.30&nbsp;&nbsp;&nbsp;&nbsp;0.69%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=QUEENSOUTH" class='abhead' target='_top'>
+											QUEENSOUTH&nbsp;15.10&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.30&nbsp;&nbsp;&nbsp;&nbsp;2.03%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="135" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=RAHIMAFOOD" class='abhead' target='_top'>
+											RAHIMAFOOD&nbsp;102.40&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.40&nbsp;&nbsp;&nbsp;&nbsp;0.39%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=RAHIMTEXT" class='abhead' target='_top'>
+											RAHIMTEXT&nbsp;196.70&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.90&nbsp;&nbsp;&nbsp;&nbsp;-0.96%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=RAKCERAMIC" class='abhead' target='_top'>
+											RAKCERAMIC&nbsp;29.90&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.60&nbsp;&nbsp;&nbsp;&nbsp;2.05%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="135" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=RANFOUNDRY" class='abhead' target='_top'>
+											RANFOUNDRY&nbsp;154.40&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.00&nbsp;&nbsp;&nbsp;&nbsp;-0.64%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="110" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=RDFOOD" class='abhead' target='_top'>
+											RDFOOD&nbsp;28.60&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.30&nbsp;&nbsp;&nbsp;&nbsp;-1.04%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="140" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=RECKITTBEN" class='abhead' target='_top'>
+											RECKITTBEN&nbsp;3330.00&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				8.70&nbsp;&nbsp;&nbsp;&nbsp;0.26%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=REGENTTEX" class='abhead' target='_top'>
+											REGENTTEX&nbsp;6.80&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.70&nbsp;&nbsp;&nbsp;&nbsp;-9.33%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=RELIANCE1" class='abhead' target='_top'>
+											RELIANCE1&nbsp;10.60&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.20&nbsp;&nbsp;&nbsp;&nbsp;-1.85%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="135" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=RELIANCINS" class='abhead' target='_top'>
+											RELIANCINS&nbsp;113.10&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				1.90&nbsp;&nbsp;&nbsp;&nbsp;1.71%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=RENATA" class='abhead' target='_top'>
+											RENATA&nbsp;435.60&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				2.30&nbsp;&nbsp;&nbsp;&nbsp;0.53%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=RENWICKJA" class='abhead' target='_top'>
+											RENWICKJA&nbsp;537.30&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-2.30&nbsp;&nbsp;&nbsp;&nbsp;-0.43%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=REPUBLIC" class='abhead' target='_top'>
+											REPUBLIC&nbsp;35.30&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.40&nbsp;&nbsp;&nbsp;&nbsp;-1.12%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=RINGSHINE" class='abhead' target='_top'>
+											RINGSHINE&nbsp;3.90&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.30&nbsp;&nbsp;&nbsp;&nbsp;8.33%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="100" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ROBI" class='abhead' target='_top'>
+											ROBI&nbsp;&nbsp;&nbsp;31.40&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.40&nbsp;&nbsp;&nbsp;&nbsp;1.29%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=RSRMSTEEL" class='abhead' target='_top'>
+											RSRMSTEEL&nbsp;8.70&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.30&nbsp;&nbsp;&nbsp;&nbsp;3.57%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=RUNNERAUTO" class='abhead' target='_top'>
+											RUNNERAUTO&nbsp;42.00&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.30&nbsp;&nbsp;&nbsp;&nbsp;0.72%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=RUPALIBANK" class='abhead' target='_top'>
+											RUPALIBANK&nbsp;16.90&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=RUPALIINS" class='abhead' target='_top'>
+											RUPALIINS&nbsp;27.40&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.30&nbsp;&nbsp;&nbsp;&nbsp;-1.08%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=RUPALILIFE" class='abhead' target='_top'>
+											RUPALILIFE&nbsp;94.80&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.90&nbsp;&nbsp;&nbsp;&nbsp;-1.96%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SAFKOSPINN" class='abhead' target='_top'>
+											SAFKOSPINN&nbsp;19.90&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.90&nbsp;&nbsp;&nbsp;&nbsp;-4.33%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SAIFPOWER" class='abhead' target='_top'>
+											SAIFPOWER&nbsp;9.30&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.80&nbsp;&nbsp;&nbsp;&nbsp;9.41%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SAIHAMCOT" class='abhead' target='_top'>
+											SAIHAMCOT&nbsp;19.90&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.20&nbsp;&nbsp;&nbsp;&nbsp;-1.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SAIHAMTEX" class='abhead' target='_top'>
+											SAIHAMTEX&nbsp;18.60&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SALAMCRST" class='abhead' target='_top'>
+											SALAMCRST&nbsp;15.10&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.67%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="105" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SALVO" class='abhead' target='_top'>
+											SALVO&nbsp;&nbsp;&nbsp;37.40&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.30&nbsp;&nbsp;&nbsp;&nbsp;0.81%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="135" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SAMATALETH" class='abhead' target='_top'>
+											SAMATALETH&nbsp;106.10&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-2.10&nbsp;&nbsp;&nbsp;&nbsp;-1.94%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SAMORITA" class='abhead' target='_top'>
+											SAMORITA&nbsp;77.60&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				3.10&nbsp;&nbsp;&nbsp;&nbsp;4.16%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SANDHANINS" class='abhead' target='_top'>
+											SANDHANINS&nbsp;25.60&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SAPORTL" class='abhead' target='_top'>
+											SAPORTL&nbsp;60.50&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				2.00&nbsp;&nbsp;&nbsp;&nbsp;3.42%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SBACBANK" class='abhead' target='_top'>
+											SBACBANK&nbsp;6.50&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-1.52%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SEAPEARL" class='abhead' target='_top'>
+											SEAPEARL&nbsp;36.90&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;0.54%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SEMLFBSLGF" class='abhead' target='_top'>
+											SEMLFBSLGF&nbsp;5.40&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SEMLIBBLSF" class='abhead' target='_top'>
+											SEMLIBBLSF&nbsp;6.40&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;3.23%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SHAHJABANK" class='abhead' target='_top'>
+											SHAHJABANK&nbsp;17.00&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.59%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SHARPIND" class='abhead' target='_top'>
+											SHARPIND&nbsp;18.90&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				1.60&nbsp;&nbsp;&nbsp;&nbsp;9.25%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SHASHADNIM" class='abhead' target='_top'>
+											SHASHADNIM&nbsp;24.00&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;0.84%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SHEPHERD" class='abhead' target='_top'>
+											SHEPHERD&nbsp;16.70&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;1.21%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="110" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SHURWID" class='abhead' target='_top'>
+											SHURWID&nbsp;7.00&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;1.45%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SHYAMPSUG" class='abhead' target='_top'>
+											SHYAMPSUG&nbsp;186.40&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-12.60&nbsp;&nbsp;&nbsp;&nbsp;-6.33%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="100" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SICL" class='abhead' target='_top'>
+											SICL&nbsp;&nbsp;&nbsp;38.90&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.90&nbsp;&nbsp;&nbsp;&nbsp;-2.26%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SILCOPHL" class='abhead' target='_top'>
+											SILCOPHL&nbsp;22.10&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.80&nbsp;&nbsp;&nbsp;&nbsp;3.76%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SILVAPHL" class='abhead' target='_top'>
+											SILVAPHL&nbsp;14.20&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.70&nbsp;&nbsp;&nbsp;&nbsp;5.19%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="110" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SIMTEX" class='abhead' target='_top'>
+											SIMTEX&nbsp;25.60&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SINGERBD" class='abhead' target='_top'>
+											SINGERBD&nbsp;81.90&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.12%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SINOBANGLA" class='abhead' target='_top'>
+											SINOBANGLA&nbsp;54.80&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.70&nbsp;&nbsp;&nbsp;&nbsp;1.29%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="110" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SIPLC" class='abhead' target='_top'>
+											SIPLC&nbsp;&nbsp;&nbsp;102.80&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.50&nbsp;&nbsp;&nbsp;&nbsp;-1.44%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="140" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SJIBLPBOND" class='abhead' target='_top'>
+											SJIBLPBOND&nbsp;5220.00&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-200.00&nbsp;&nbsp;&nbsp;&nbsp;-3.69%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SKTRIMS" class='abhead' target='_top'>
+											SKTRIMS&nbsp;14.40&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.60&nbsp;&nbsp;&nbsp;&nbsp;4.35%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="135" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SONALIANSH" class='abhead' target='_top'>
+											SONALIANSH&nbsp;183.50&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.20&nbsp;&nbsp;&nbsp;&nbsp;-0.65%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SONALILIFE" class='abhead' target='_top'>
+											SONALILIFE&nbsp;84.10&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.70&nbsp;&nbsp;&nbsp;&nbsp;0.84%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="135" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SONALIPAPR" class='abhead' target='_top'>
+											SONALIPAPR&nbsp;231.40&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				3.00&nbsp;&nbsp;&nbsp;&nbsp;1.31%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SONARBAINS" class='abhead' target='_top'>
+											SONARBAINS&nbsp;44.90&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.30&nbsp;&nbsp;&nbsp;&nbsp;-0.66%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SONARGAON" class='abhead' target='_top'>
+											SONARGAON&nbsp;78.60&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-5.40&nbsp;&nbsp;&nbsp;&nbsp;-6.43%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SOUTHEASTB" class='abhead' target='_top'>
+											SOUTHEASTB&nbsp;9.90&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-1.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SPCERAMICS" class='abhead' target='_top'>
+											SPCERAMICS&nbsp;24.30&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.80&nbsp;&nbsp;&nbsp;&nbsp;3.40%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="100" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SPCL" class='abhead' target='_top'>
+											SPCL&nbsp;&nbsp;&nbsp;54.30&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SQUARETEXT" class='abhead' target='_top'>
+											SQUARETEXT&nbsp;49.10&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-0.20%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="135" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SQURPHARMA" class='abhead' target='_top'>
+											SQURPHARMA&nbsp;217.90&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				1.00&nbsp;&nbsp;&nbsp;&nbsp;0.46%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="110" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SSSTEEL" class='abhead' target='_top'>
+											SSSTEEL&nbsp;6.80&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.40&nbsp;&nbsp;&nbsp;&nbsp;6.25%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=STANCERAM" class='abhead' target='_top'>
+											STANCERAM&nbsp;72.50&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.30&nbsp;&nbsp;&nbsp;&nbsp;-0.41%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=STANDARINS" class='abhead' target='_top'>
+											STANDARINS&nbsp;52.50&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.60&nbsp;&nbsp;&nbsp;&nbsp;-1.13%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=STANDBANKL" class='abhead' target='_top'>
+											STANDBANKL&nbsp;4.80&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=STYLECRAFT" class='abhead' target='_top'>
+											STYLECRAFT&nbsp;53.10&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SUMITPOWER" class='abhead' target='_top'>
+											SUMITPOWER&nbsp;15.20&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.50&nbsp;&nbsp;&nbsp;&nbsp;3.40%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SUNLIFEINS" class='abhead' target='_top'>
+											SUNLIFEINS&nbsp;67.50&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-4.70&nbsp;&nbsp;&nbsp;&nbsp;-6.51%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=TAKAFULINS" class='abhead' target='_top'>
+											TAKAFULINS&nbsp;38.90&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.60&nbsp;&nbsp;&nbsp;&nbsp;1.57%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=TALLUSPIN" class='abhead' target='_top'>
+											TALLUSPIN&nbsp;8.80&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.40&nbsp;&nbsp;&nbsp;&nbsp;4.76%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=TAMIJTEX" class='abhead' target='_top'>
+											TAMIJTEX&nbsp;128.50&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.00&nbsp;&nbsp;&nbsp;&nbsp;-0.77%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=TB10Y0434" class='abhead' target='_top'>
+											TB10Y0434&nbsp;107.41&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-2.28&nbsp;&nbsp;&nbsp;&nbsp;-2.08%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=TB10Y1135" class='abhead' target='_top'>
+											TB10Y1135&nbsp;101.72&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				1.13&nbsp;&nbsp;&nbsp;&nbsp;1.12%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=TB2Y0327" class='abhead' target='_top'>
+											TB2Y0327&nbsp;101.46&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.65&nbsp;&nbsp;&nbsp;&nbsp;0.64%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=TB2Y1026" class='abhead' target='_top'>
+											TB2Y1026&nbsp;100.59&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.02&nbsp;&nbsp;&nbsp;&nbsp;-0.02%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=TB5Y1229" class='abhead' target='_top'>
+											TB5Y1229&nbsp;105.05&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.57&nbsp;&nbsp;&nbsp;&nbsp;-1.47%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=TECHNODRUG" class='abhead' target='_top'>
+											TECHNODRUG&nbsp;42.50&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-0.23%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="105" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=TILIL" class='abhead' target='_top'>
+											TILIL&nbsp;&nbsp;&nbsp;54.20&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.70&nbsp;&nbsp;&nbsp;&nbsp;-1.28%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=TITASGAS" class='abhead' target='_top'>
+											TITASGAS&nbsp;17.70&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.20&nbsp;&nbsp;&nbsp;&nbsp;-1.12%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=TOSRIFA" class='abhead' target='_top'>
+											TOSRIFA&nbsp;20.90&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=TRUSTB1MF" class='abhead' target='_top'>
+											TRUSTB1MF&nbsp;3.10&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=TRUSTBANK" class='abhead' target='_top'>
+											TRUSTBANK&nbsp;15.60&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-0.64%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="110" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=TUNGHAI" class='abhead' target='_top'>
+											TUNGHAI&nbsp;3.10&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;3.33%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="90" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=UCB" class='abhead' target='_top'>
+											UCB&nbsp;&nbsp;&nbsp;9.10&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.30&nbsp;&nbsp;&nbsp;&nbsp;3.41%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="140" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=UNILEVERCL" class='abhead' target='_top'>
+											UNILEVERCL&nbsp;2053.00&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-7.20&nbsp;&nbsp;&nbsp;&nbsp;-0.35%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=UNIONCAP" class='abhead' target='_top'>
+											UNIONCAP&nbsp;4.80&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-2.04%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=UNIONINS" class='abhead' target='_top'>
+											UNIONINS&nbsp;40.10&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.90&nbsp;&nbsp;&nbsp;&nbsp;-2.20%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=UNIQUEHRL" class='abhead' target='_top'>
+											UNIQUEHRL&nbsp;41.30&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.20&nbsp;&nbsp;&nbsp;&nbsp;-0.48%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=UNITEDFIN" class='abhead' target='_top'>
+											UNITEDFIN&nbsp;15.60&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.30&nbsp;&nbsp;&nbsp;&nbsp;-1.89%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=UNITEDINS" class='abhead' target='_top'>
+											UNITEDINS&nbsp;43.50&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.70&nbsp;&nbsp;&nbsp;&nbsp;-1.58%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=UPGDCL" class='abhead' target='_top'>
+											UPGDCL&nbsp;125.00&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;0.16%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=USMANIAGL" class='abhead' target='_top'>
+											USMANIAGL&nbsp;45.20&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				1.20&nbsp;&nbsp;&nbsp;&nbsp;2.73%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=UTTARABANK" class='abhead' target='_top'>
+											UTTARABANK&nbsp;21.50&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-0.46%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=UTTARAFIN" class='abhead' target='_top'>
+											UTTARAFIN&nbsp;13.90&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=VAMLRBBF" class='abhead' target='_top'>
+											VAMLRBBF&nbsp;6.80&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;1.49%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="110" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=VFSTDL" class='abhead' target='_top'>
+											VFSTDL&nbsp;17.10&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.59%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=WALTONHIL" class='abhead' target='_top'>
+											WALTONHIL&nbsp;380.90&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				3.80&nbsp;&nbsp;&nbsp;&nbsp;1.01%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=WATACHEM" class='abhead' target='_top'>
+											WATACHEM&nbsp;133.90&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-0.07%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=WMSHIPYARD" class='abhead' target='_top'>
+											WMSHIPYARD&nbsp;9.00&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;2.27%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="95" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=YPL" class='abhead' target='_top'>
+											YPL&nbsp;&nbsp;&nbsp;24.90&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.30&nbsp;&nbsp;&nbsp;&nbsp;1.22%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ZAHEENSPIN" class='abhead' target='_top'>
+											ZAHEENSPIN&nbsp;6.10&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.30&nbsp;&nbsp;&nbsp;&nbsp;5.17%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ZAHINTEX" class='abhead' target='_top'>
+											ZAHINTEX&nbsp;9.00&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.30&nbsp;&nbsp;&nbsp;&nbsp;3.45%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="135" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ZEALBANGLA" class='abhead' target='_top'>
+											ZEALBANGLA&nbsp;126.50&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-2.70&nbsp;&nbsp;&nbsp;&nbsp;-2.09%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+										</tr>
+					</table>
+				</marquee>
+			</div>
+			<div class="scroller-ticker">
+				<img id="IMG1" name="IMG1" src="assets/imgs/stop.gif" style="display:block" onClick="swapImagess();" width="10" height="11">
+				<img id="IMG2" name="IMG2" src="assets/imgs/fast.jpg" style="display:block" alt="Increase the speed of the ticker" onClick="swapImagespeed();" width="10" height="11">
+				<img id="IMG3" name="IMG3" style="display:block" src="assets/imgs/right.jpg" alt="Set the ticker's scrolling direction to right" onClick="swapImagedir();" width="10" height="12">
+			</div>
+		</div>
+	</div>
+	<div class="clearfix"></div>
+
+	<style type="text/css">
+.menucolor .nav-item .nav-link {
+	color: #fff !important;
+	font-size: 12px;
+}
+.nav>li>a {
+	padding: 5px 5px!important;
+}
+
+@media (min-width: 320px) {
+.navbar-nav .open .dropdown-menu>li>a {
+	font-size: 12px !important;
+}
+}
+
+@media screen and (min-width: 640px) {
+.mainmenu {
+	padding: 1px !important;
+}
+/*Off 18 january 2022*/
+        /*.navbar-nav .nav-item{
+            padding-right: 20px;
+        }*/
+
+        /*add 18 january 2022*/
+.navbar-nav .nav-item a {
+	padding-left: 15px !important;
+	padding-right: 15px !important;
+}
+.dropdown-menu>li>a {
+	padding-top: 5px !important;
+	padding-bottom: 5px !important;
+}
+}
+
+@media screen and (max-width: 640px) {
+.mainmenu {
+	margin-top: 35px !important;
+	/*padding: 15px !important;*/
+	padding-left: 15px !important;
+	padding-right: 15px !important;
+	border-bottom: 1px #dedede solid;
+}
+.navbar-nav .nav-link {
+	padding-left: 10px;
+	border-bottom: 1px #dedede solid;
+}
+.navbar-collapse {
+	border-top: 2px #dedede solid;
+}
+.mobile-version a {
+	padding-left: 5px;
+}
+}
+.navbar-toggler, .navbar-toggler:focus, .navbar-toggler:active, .navbar-toggler-icon:focus {
+	outline: none;
+	border: none;
+	box-shadow: none;
+}
+</style>
+<nav class="navbar navbar-expand-lg navbar-light bg-light mainmenu" style="background: linear-gradient(to bottom,#015f70 0,#004149 100%) !important;">
+<!-- <nav role="navigation" class="navbar navbar-default mainmenu"> -->
+<!-- Brand and toggle get grouped for better mobile display -->
+<!-- <span class="navbar-brand mobile-version"><a href="https://dsebd.org/amp" style="font-size: 14px;">Lite Version</a></span> -->
+
+<span class="mobile-version"><a href="https://dsebd.org/amp" style="font-size: 14px;">Lite Version</a></span> 
+<!-- <div class="navbar-header">
+        <button type="button" data-target="#navbarCollapse" data-toggle="collapse" class="navbar-toggle">
+            <span class="sr-only">Toggle navigation</span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+        </button>
+    </div> --> 
+<a class="navbar-brand" href="#"></a>
+<button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation"> <span class="navbar-toggler-icon"></span> </button>
+
+<!-- Collection of nav links and other content for toggling -->
+<div id="navbarCollapse" class="collapse navbar-collapse">
+<!-- <span class="mobile-version"><a href="//web1/dse">Switch to Light Version</a></span> -->
+
+<ul id="fresponsive" class="nav navbar-nav dropdown menucolor wh-sp-nw">
+<li class="active nav-item"><a class="nav-link" href="index.php">Home</a></li>
+<!-- <li class="nav-item dropdown">
+              <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                Dropdown
+              </a>
+              <ul class="dropdown-menu" aria-labelledby="navbarDropdown">
+                <li><a class="nav-link" href="ilf.php">Introduction to DSE</a></li>
+                <li><a class="dropdown-item" href="#">Action</a></li>
+                <li><a class="dropdown-item" href="#">Another action</a></li>
+                <li><hr class="dropdown-divider"></li>
+                <li><a class="dropdown-item" href="#">Something else here</a></li>
+              </ul>
+            </li> -->
+<li class="nav-item dropdown"> <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false" style="padding: 10px;"> About Us <b class="caret"></b> </a>
+  <ul class="dropdown-menu" aria-labelledby="navbarDropdown">
+    <li><a class="nav-link" href="ilf.php">Introduction to DSE</a></li>
+    <li><a class="nav-link" href="vision.php">Mission and Vision</a></li>
+    <li><a class="nav-link" href="dseglance.php">DSE at a Glance</a></li>
+    <li><a class="nav-link" href="directors.php">Board of Directors</a></li>
+    <li class="dropdown-submenu" aria-labelledby="navbarDropdown"> <a href="#" id="navbarDropdown" class="dropdown-toggle nav-link" data-bs-toggle="dropdown" aria-expanded="false">Board Committees<span class="caret"></a>
+      <ul class="dropdown-menu">
+        <li><a class="nav-link" href="committee_nomination.php">Nomination and Remuneration Committee</a></li>
+        <li><a class="nav-link" href="committee_regulatory.php">Regulatory Affairs Committee</a></li>
+        <li><a class="nav-link" href="committee_audit_risk_management.php">Audit and Risk Management Committee</a></li>
+        <li><a class="nav-link" href="committee_appeals.php">Appeals Committee</a></li>
+        <li><a class="nav-link" href="committee_conflict_mitigation.php">Conflict Mitigation Committee</a></li>
+        <li><a class="nav-link" href="committee_IT_Advisory.php">IT Advisory and Strategy Development Committee </a></li>
+      </ul>
+    </li>
+    <li><a class="nav-link" href="manag.php">DSE Management</a></li>
+    <li><a class="nav-link" href="president_chairmen_of_dse_with_photo.php">DSE Presidents/Chairmen</a></li>
+    <li><a class="nav-link" href="ilf.php#lc" >Legal Control</a></li>
+    <li><a class="nav-link" href="ilf.php#fnd" >Function of DSE</a></li>
+    <li><a class="nav-link" href="settle.php">Clearing &amp; Settlement</a></li>
+    <li class="dropdown-submenu"><a href="#" class="dropdown-toggle nav-link" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">DSE Indices <b class="caret"></b></a>
+      <ul class="dropdown-menu">
+        <li><a class="nav-link" href="assets/pdf/DSEX_DS30.pdf">Index developed by S&amp;P</a></li>
+        <li><a class="nav-link" href="assets/pdf/DSES.pdf">DSEX Shariah Index Methodology</a></li>
+        <li><a class="nav-link" href="dse_algorithm.php">Algorithm of DSE Indices</a></li>
+        <li><a class="nav-link" href="dseX_share.php">DSEX Index</a></li>
+        <li><a class="nav-link" href="dse30_share.php">DS30 Index</a></li>
+      </ul>
+    </li>
+    <li><a class="nav-link" href="hts.php">Holidays &amp; Trading Sessions</a></li>
+    <!--<li><a class="nav-link" href="presidents.php">DSE Presidents/Chairmen</a></li> -->
+    <li><a class="nav-link" href="dse_dept.php">Departments of DSE</a></li>
+    <li><a class="nav-link" href="search_member_with_branch.php">TREC Holders' Directory</a></li>
+    <!--<li><a class="nav-link" href="pdf/DSEATS.pdf">Automated Trading System</a></li>
+                <li><a class="nav-link" href="pdf/MandA.pdf">Memorandum & Articles of Association</a></li>-->
+    <li><a class="nav-link" href="surv.php">Surveillance</a></li>
+    <li><a class="nav-link" href="dse-annual-report.php">Annual Report</a></li>
+  </ul>
+</li>
+<li class="nav-item dropdown"> <a href="#" class="dropdown-toggle nav-link" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Market Updates <b class="caret"></b></a>
+  <ul class="dropdown-menu">
+    <li class="dropdown-submenu"><a href="#" class="dropdown-toggle nav-link" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Market Updates <b class="caret"></b></a>
+      <ul class="dropdown-menu">
+        <li><a class="nav-link" href="top_20_share.php">Top 20 Share</a></li>
+        <li><a class="nav-link" href="latest_share_price_scroll_l.php">Latest Share Price</a></li>
+      </ul>
+    </li>
+    <li><a class="nav-link" href="news_archive.php#lc">Valid Announcements</a></li>
+    <li><a class="nav-link" href="cbul.php">Circuit Breaker</a></li>
+    <li><a class="nav-link" href="top_ten_gainer.php">Top 10 Gainers</a></li>
+    <li><a class="nav-link" href="top_ten_loser.php">Top 10 Losers</a></li>
+    <li><a class="nav-link" href="market-statistics.php">Market Statistics</a></li>
+    <li><a class="nav-link" href="CompAGM&amp;RecordDate.php">Companies AGM/EGM and Record Date</a></li>
+    <li><a class="nav-link" href="recent_market_information.php">Recent Market Information</a></li>
+    <li><a class="nav-link" href="mrg.php">Monthly Reviews &amp; Graphs</a></li>
+    <li><a class="nav-link" href="Fortnightly_Capital_Market.php">Fortnightly Capital Market</a></li>
+    <li><a class="nav-link" href="markets.php">Comparison of Market</a></li>
+  </ul>
+</li>
+<li class="nav-item dropdown"> <a href="#" class="dropdown-toggle nav-link" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Rules &amp; Regulations <b class="caret"></b></a>
+  <ul class="dropdown-menu">
+    <li><a class="nav-link" href="trecregulation.php">TREC Regulations</a></li>
+    <li><a class="nav-link" href="Listing_rule.php">Listing Regulations</a></li>
+    <li><a class="nav-link" href="assets/pdf/DemuAct2013.pdf">The Exchanges Demutualization Act 2013 </a></li>
+    <li><a class="nav-link" href="assets/pdf/Demutualization Schme.pdf">Demutualization Scheme </a></li>
+    <li><a class="nav-link" href="assets/pdf/MandA.pdf">Memorandum and Articles of Association </a></li>
+    <li><a class="nav-link" href="Corporate_Governance_Code.php">Corporate Governance Code</a></li>
+    <li><a class="nav-link" href="settlementrule.php">Settlement Regulations</a></li>
+    <li><a class="nav-link" href="assets/pdf/SGF-7082014130507.pdf">Settlement Guarantee Fund Regulations-2013</a></li>
+    <li><a class="nav-link" href="https://www.dsebd.org/SettlementofDisputeRegulationse.php">Settlement of Dispute Regulations, 2026</a></li>
+    
+	<li><a class="nav-link" href="assets/pdf/shortSaleReg.pdf">Short-Sale Regulations-2006</a></li>
+    <li><a class="nav-link" href="assets/pdf/auto_trade.pdf">Automated Trading Regulations-99</a></li>
+    <li><a class="nav-link" href="ipfr.php">Investors Protection Fund Regulations</a></li>
+    <li><a class="nav-link" href="margin_rules.php">Margin Rules</a></li>
+    <li><a class="nav-link" href="memmarginregulation.php">TREC Holder Margin Regulations</a></li>
+    <li><a class="nav-link" href="boardadmin.php">Board and Administration Regulations</a></li>
+    <li><a class="nav-link" href="https://sec.gov.bd/home/laws" target="_blank">Securities Related Laws</a></li>
+  </ul>
+</li>
+<li class="nav-item dropdown"> <a href="#" class="dropdown-toggle nav-link" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Companies'/ Securities' Info <b class="caret"></b></a>
+  <ul class="dropdown-menu">
+    <li><a class="nav-link" href="company_listing.php">Listed Companies/ Securities</a></li>
+    <li><a class="nav-link" href="https://www.dsebd.org/Non_operational_Companies_info.php">Closed/Non-operational Companies</a></li>
+    <li><a class="nav-link" href="CompAGM&amp;RecordDate.php">Companies´ AGM/ EGM and Record Date</a></li>
+  <!--  <li><a class="nav-link" href="ipo.php">New Issues (IPO)</a></li>  -->
+    <li><a class="nav-link" href="rights_issue_utilisation.php">IPO/ RPO/ Rights Proceeds Utilisation</a></li>
+    <li class="dropdown-submenu"><a href="#" class="dropdown-toggle nav-link" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Marginable Securities <b class="caret"></b></a>
+      <ul class="dropdown-menu">
+        <li><a class="nav-link" href="marginable-securities.php">Margin Financeable Securities</a></li>
+        <li><a class="nav-link" href="latest_PE.php">P/E at a glance</a></li>
+        <li><a class="nav-link" href="sectoral_PE.php">Sectoral Median P/E</a></li>
+		  <li><a class="nav-link" href="going-concern-threat-list.php">Going Concern threat List</a></li>
+		  <li><a class="nav-link" href="actuarial-valuation-status.php">Actuarial Valuation Conduction Status</a></li>
+      </ul>
+    </li>
+    <li><a class="nav-link" href="financial-statement-submission-status-extended.php">Financial Statements Submission Status</a></li>
+  </ul>
+</li>
+<li class="nav-item dropdown"> <a href="#" class="dropdown-toggle nav-link" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Investor Guide<b class="caret"></b></a>
+  <ul class="dropdown-menu">
+    <li><a class="nav-link" href="genprof.php">General Profile of Bangladesh</a></li>
+    <li><a class="nav-link" href="ecobd.php">Economy of Bangladesh</a></li>
+    <li><a class="nav-link" href="mglc.php">Market at a Glance</a></li>
+    <li><a class="nav-link" href="assets/pdf/facilitiesForForeignInvestors.pdf">Opportunity for Foreign Investors</a></li>
+    <li><a class="nav-link" href="assets/pdf/facilitiesForNRB.pdf">Facilities for Non-resident Bangladeshis</a></li>
+    <!--<li><a class="nav-link" href="feu.php">Financial & Economical Updates</a></li>-->
+    <li><a class="nav-link" href="share_transfer_procedure.php">Process of Gift/ Transfer of Shares</a></li>
+    <li><a class="nav-link" href="dse_faq.php">FAQ</a></li>
+  </ul>
+</li>
+<li class="nav-item dropdown"> <a href="#" class="dropdown-toggle nav-link" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Listing <b class="caret"></b></a>
+  <ul class="dropdown-menu">
+    <li><a class="nav-link" href="benifits_of_listing.php">Benefits of Listing</a></li>
+    <li><a class="nav-link" href="why_dse_listing.php">Why List With DSE</a></li>
+    <li><a class="nav-link" href="why_dse_listing.php#methods">Methods of Listing</a></li>
+  <!--  <li><a class="nav-link" href="provision_for_listing.php">Provisions of Mandatory Listing</a></li>   -->
+    <li><a class="nav-link" href="criteria_for_listing.php">Eligibility Criteria for Listing</a></li>
+    <li><a class="nav-link" href="listing_procedure.php">Listing Procedure/Listing Guidebook</a></li>
+    <li><a class="nav-link" href="listing_timeline.php">Listing Time Line</a></li>
+	<li><a class="nav-link" href="Eligible_Investors.php">Eligible Investors (EIs)</a></li>
+    <!--<li><a href="#">Listing Center- Support Desk</a></li>
+                    <li><a href="#">Major Rules & Regulations for listing</a></li>
+    <li class="dropdown-submenu"> <a href="#" class="dropdown-toggle nav-link" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">New Public Offerings</a>
+      <ul class="dropdown-menu">
+        <li><a class="nav-link" href="fixedpriceipo.php">Fixed Price</a></li>
+        <li><a class="nav-link" href="bookbuildingipo.php">Book Building</a></li>
+        <li><a class="nav-link" href="directlisting.php">Direct Listing</a></li>
+      </ul>
+    </li>  
+    <li><a class="nav-link" href="rightoffers.php">Rights Offer</a></li>  -->
+    <li><a class="nav-link" href="listing_fees.php">Listing Fees</a></li>
+    <li><a class="nav-link" href="share_transfer_procedure.php">Share Transfer Process</a></li>
+    <li><a class="nav-link" href="listing_reg_2015.php">Formats Under Listing Regulation</a></li>
+    <!--li><a class="nav-link" href="complaintCell.php">E-Investor’s Complaint</a></li>
+                    <li><a class="nav-link" href="#">Downloads</a></li>
+                    <li><a class="nav-link" href="#">FAQs</a></li>   -->
+  </ul>
+</li>
+<li class="nav-item dropdown"> <a href="#" class="dropdown-toggle nav-link" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Products<b class="caret"></b></a>
+  <ul class="dropdown-menu">
+    <li><a class="nav-link" href="products_of_dse.php">Equity</a></li>
+    <li><a class="nav-link" href="products_of_dse.php#Debt">Debt</a></li>
+    <li><a class="nav-link" href="products_of_dse.php#FutureProd">Future Products</a></li>
+    <li class="dropdown-submenu"> <a href="#" class="dropdown-toggle nav-link" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">OMS Services</a>
+      <ul class="dropdown-menu">
+        <li><a class="nav-link" href="dse-mobile.php">DSE-Mobile Service</a></li>
+        <li><a class="nav-link" href="assets/pdf/BHOMS_Brochure_v1.1.pdf">API for BHOMS</a></li>
+      </ul>
+    </li>
+    <li class="dropdown-submenu"> <a href="#" class="dropdown-toggle nav-link" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">DSE Data Services</a>
+      <ul class="dropdown-menu">
+        <li><a class="nav-link" href="assets/pdf/Introduction of DSE Data Sale Services.pdf">Introduction</a></li>
+        <li><a class="nav-link" href="assets/pdf/iMDS.pdf">MDS</a></li>
+        <li><a class="nav-link" href="assets/pdf/EOD.pdf">EOD</a></li>
+      </ul>
+    </li>
+  </ul>
+</li>
+<li class="nav-item dropdown">
+<a href="#" class="dropdown-toggle nav-link" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Sustainability<b class="caret"></b></a>
+<ul class="dropdown-menu">
+  <li><a class="nav-link" href="https://dsebd.org/GRI-about.php">About</a></li>
+  <li><a class="nav-link" href="https://dsebd.org/GRI-SSE-Initiatives.php">SSE Initiative Members</a></li>
+  <li class="dropdown-submenu"> <a href="#" class="dropdown-toggle nav-link" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">GRI</a>
+    <ul class="dropdown-menu">
+      <li><a class="nav-link" href="https://www.globalreporting.org/about-gri/gri-in-south-asia/" target="_blank">GRI Home Page</a></li>
+      <li><a class="nav-link" href="https://dsebd.org/assets/pdf/GRI/DSE-&-GRI-Collaborations.pdf">DSE and GRI Collaboration</a></li>
+      <li><a class="nav-link" href="https://dsebd.org/assets/pdf/GRI/Guidance-Document-for-Sustainability-Reporting-Based-On-GRI.pdf">Guidance on Reporting</a></li>
+      <li><a class="nav-link" href="https://dsebd.org/GRI-training.php">Training and Seminars</a></li>
+      <li><a class="nav-link" href="https://dsebd.org/GRI-Publication.php">Publications and Reporting</a></li>
+      <li><a class="nav-link" href="https://dsebd.org/GRI-Media.php">Media Coverage</a></li>
+    </ul>
+  <li><a class="nav-link" href="https://dsebd.org/GRI-ifc.php">IFC</a></li>
+  <li><a class="nav-link" href="https://dsebd.org/assets/pdf/GRI/dec312020sfd05.pdf" target="_blank">Bangladesh Bank Policy</a></li>
+  </li>
+</ul>
+<li class="nav-item"><a class="nav-link" href="contact.php">Contact Us</a></li>
+</div>
+</nav>
+</header>    </div>
+  </div>
+  <div class="clearfix"></div>
+  <section class="content">
+    <div class="gray">
+      <div class="col-md-2 LeftCol">
+        <style type="text/css">
+a:link {
+	text-decoration: none;
+}
+a:visited {
+	text-decoration: none;
+}
+a:hover {
+	text-decoration: none;
+}
+a:active {
+	text-decoration: none;
+}
+</style>
+
+<div class="LeftBox">
+  <h2 class="LeftHeading">Market Highlights</h2>
+  <ul class="InLmenu">
+    <li><a href="mkt_depth_3.php">Market Price</a></li>
+    <li><a href="top_20_share.php">Top 20 Shares</a></li>
+    <li><a href="dseX_share.php">DSE<strong><font size="2">X &nbsp;</font></strong></a></li>
+    <li><a href="dse30_share.php">DS30</a></li>
+    <li><a href="news_archive.php">News</a></li>
+  </ul>
+</div>
+<div class="LeftBox">
+  <h2 class="LeftHeading">Latest Share Price</h2>
+  <ul class="InLmenu">
+    <li><a href="latest_share_price_scroll_l.php">By Trade Code</a></li>
+    <li><a href="latest_share_price_scroll_by_change.php">By % Change</a></li>
+    <li><a href="latest_share_price_scroll_by_value.php"> By Value</a></li>
+    <li><a href="latest_share_price_scroll_by_volume.php"> By Volume</a></li>
+    <li><a href="latest_share_price_scroll_by_ltp.php"> By Last Trade Price</a></li>
+    <li><a href="latest_share_price_scroll_group.php">By Category</a></li>
+    <li><a href="latest_share_price_alpha.php" target="_top">By Alphabetic Order</a></li>
+    <li><a href="https://www.dsebd.org/datafile/quotes_script.php" target="_blank">In Text Mode</a></li>
+    <li><a href="latest_share_price_scroll_treasury_bond.php">DEBT Board</a></li>
+    <li><a href="https://www.dsebd.org/government-securities.php">G-Sec</a></li>
+  </ul>
+</div>
+<div class="LeftBox">
+  <h2 class="LeftHeading">Search Company</h2>
+  <center>
+    <p>Enter Company's Trading code</p>
+    <!-- <form action="SearchCompany.php" method="submit" name="form" target="_top" onsubmit="return chkform();"> -->
+    <p class="imgSearchParent">
+      <input name="name" class="form-control textNumber textCompany" size="20" type="text">
+      <!-- <img src="assets/images/search.png" class="imgCompanySearch imgSearch" alt="S"> --> 
+    </p>
+    <p>
+      <input value="Submit" class="btn btn-primary btn-sm btnCompanySearch" name="btnCompanySearch" type="button">
+    </p>
+    <!-- </form> -->
+  </center>
+  <ul class="InLmenu">
+    <li><a href="company_listing.php">Company Listing</a></li>
+    <li><a href="by_industrylisting.php">Sector wise Company List</a></li>
+  </ul>
+</div>
+<div class="LeftBox">
+  <h2 class="LeftHeading">Search TREC Holder</h2>
+  <ul class="InLmenu">
+    <li><a href="list_of_member.php">By Alphabetic Order</a></li>
+    <li><a href="search_member_by_location.php">By Location</a></li>
+    <li><a href="search_member_with_branch.php">TREC Holders' Directory</a></li>
+  </ul>
+  <center>
+    <p>Enter TREC Holder Name</p>
+    <!-- <form method="POST" action="SearchCompany.php" name="form" onsubmit="return chkform();"> -->
+    <p class="imgSearchParent">
+      <input name="name" class="form-control textNumber textTRECHolder" size="20" type="text" >
+    </p>
+    <!-- <input name="ser_cat" value="member" type="hidden"><br> -->
+    <p>
+      <input value="Submit" class="btn btn-primary btn-sm btnTRECHolderSearch" name="btnCompanySearch2" type="button">
+    </p>
+    <!-- </form> -->
+  </center>
+</div>
+<div class="LeftBox">
+  <h2 class="LeftHeading">Market Information</h2>
+  <ul class="InLmenu">
+    <li><a href="cbul.php">Circuit Breaker</a></li>
+    <li><a href="recent_market_information.php">Recent Market Information</a></li>
+    <li><a href="data_archive.php">Data Archive</a></li>
+    <li><a href="weekly_report.pdf">Weekly Report</a></li>
+  </ul>
+</div>
+<div class="LeftBox">
+  <h2 class="LeftHeading">Day End Statistics</h2>
+  <ul class="InLmenu">
+    <li><a href="market-statistics.php">Market Statistics</a></li>
+    <li><a href="top_ten_gainer.php">Top 10 Gainers</a></li>
+    <li><a href="top_ten_loser.php">Top 10 Losers</a></li>
+    <li><a href="dse_close_price.php">Close Price</a></li>
+    <li><a href="latest_PE.php">P/E at a glance</a></li>
+    <!--li><a href="assets/pdf/marginable-securities.pdf">Margin Financeable Securities</a></li-->
+    <li><a href="marginable-securities.php">Margin Financeable Securities</a></li>
+  </ul>
+</div>
+<table width="100%" cellspacing="2" cellpadding="0" border="0">
+  <tbody>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="Training_Academy_2.b.php"> DSE Training Academy </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="otc.php"> OTC Market </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="vision.php"> Vision &amp; Mission </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="dse_tower_progress.php"> DSE Tower Progress </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="dseglance.php"> DSE at a glance </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="press.php"> Press Release </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="picture_gallery.php"> Picture Gallery </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="ipo.php"> IPO </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="new.php"> Major Events </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="rightoffers.php"> Rights Offer Document </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="directlisting.php"> Direct Listing </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="cdbl.php"> CDBL </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="inquirydesk.php"> Inquiry Desk </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="complaintCell.php"> Complaint Cell </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="helpdesk_nrb.php"> Helpdesk for NRB </a></td>
+    </tr>
+  </tbody>
+</table>
+      </div>
+      <div id="mySidenav" class="sidenav"> <a href="javascript:void(0)" class="closebtn" onclick="closeNav()">&times;</a>
+        <style type="text/css">
+a:link {
+	text-decoration: none;
+}
+a:visited {
+	text-decoration: none;
+}
+a:hover {
+	text-decoration: none;
+}
+a:active {
+	text-decoration: none;
+}
+</style>
+
+<div class="LeftBox">
+  <h2 class="LeftHeading">Market Highlights</h2>
+  <ul class="InLmenu">
+    <li><a href="mkt_depth_3.php">Market Price</a></li>
+    <li><a href="top_20_share.php">Top 20 Shares</a></li>
+    <li><a href="dseX_share.php">DSE<strong><font size="2">X &nbsp;</font></strong></a></li>
+    <li><a href="dse30_share.php">DS30</a></li>
+    <li><a href="news_archive.php">News</a></li>
+  </ul>
+</div>
+<div class="LeftBox">
+  <h2 class="LeftHeading">Latest Share Price</h2>
+  <ul class="InLmenu">
+    <li><a href="latest_share_price_scroll_l.php">By Trade Code</a></li>
+    <li><a href="latest_share_price_scroll_by_change.php">By % Change</a></li>
+    <li><a href="latest_share_price_scroll_by_value.php"> By Value</a></li>
+    <li><a href="latest_share_price_scroll_by_volume.php"> By Volume</a></li>
+    <li><a href="latest_share_price_scroll_by_ltp.php"> By Last Trade Price</a></li>
+    <li><a href="latest_share_price_scroll_group.php">By Category</a></li>
+    <li><a href="latest_share_price_alpha.php" target="_top">By Alphabetic Order</a></li>
+    <li><a href="https://www.dsebd.org/datafile/quotes_script.php" target="_blank">In Text Mode</a></li>
+    <li><a href="latest_share_price_scroll_treasury_bond.php">DEBT Board</a></li>
+    <li><a href="https://www.dsebd.org/government-securities.php">G-Sec</a></li>
+  </ul>
+</div>
+<div class="LeftBox">
+  <h2 class="LeftHeading">Search Company</h2>
+  <center>
+    <p>Enter Company's Trading code</p>
+    <!-- <form action="SearchCompany.php" method="submit" name="form" target="_top" onsubmit="return chkform();"> -->
+    <p class="imgSearchParent">
+      <input name="name" class="form-control textNumber textCompany" size="20" type="text">
+      <!-- <img src="assets/images/search.png" class="imgCompanySearch imgSearch" alt="S"> --> 
+    </p>
+    <p>
+      <input value="Submit" class="btn btn-primary btn-sm btnCompanySearch" name="btnCompanySearch" type="button">
+    </p>
+    <!-- </form> -->
+  </center>
+  <ul class="InLmenu">
+    <li><a href="company_listing.php">Company Listing</a></li>
+    <li><a href="by_industrylisting.php">Sector wise Company List</a></li>
+  </ul>
+</div>
+<div class="LeftBox">
+  <h2 class="LeftHeading">Search TREC Holder</h2>
+  <ul class="InLmenu">
+    <li><a href="list_of_member.php">By Alphabetic Order</a></li>
+    <li><a href="search_member_by_location.php">By Location</a></li>
+    <li><a href="search_member_with_branch.php">TREC Holders' Directory</a></li>
+  </ul>
+  <center>
+    <p>Enter TREC Holder Name</p>
+    <!-- <form method="POST" action="SearchCompany.php" name="form" onsubmit="return chkform();"> -->
+    <p class="imgSearchParent">
+      <input name="name" class="form-control textNumber textTRECHolder" size="20" type="text" >
+    </p>
+    <!-- <input name="ser_cat" value="member" type="hidden"><br> -->
+    <p>
+      <input value="Submit" class="btn btn-primary btn-sm btnTRECHolderSearch" name="btnCompanySearch2" type="button">
+    </p>
+    <!-- </form> -->
+  </center>
+</div>
+<div class="LeftBox">
+  <h2 class="LeftHeading">Market Information</h2>
+  <ul class="InLmenu">
+    <li><a href="cbul.php">Circuit Breaker</a></li>
+    <li><a href="recent_market_information.php">Recent Market Information</a></li>
+    <li><a href="data_archive.php">Data Archive</a></li>
+    <li><a href="weekly_report.pdf">Weekly Report</a></li>
+  </ul>
+</div>
+<div class="LeftBox">
+  <h2 class="LeftHeading">Day End Statistics</h2>
+  <ul class="InLmenu">
+    <li><a href="market-statistics.php">Market Statistics</a></li>
+    <li><a href="top_ten_gainer.php">Top 10 Gainers</a></li>
+    <li><a href="top_ten_loser.php">Top 10 Losers</a></li>
+    <li><a href="dse_close_price.php">Close Price</a></li>
+    <li><a href="latest_PE.php">P/E at a glance</a></li>
+    <!--li><a href="assets/pdf/marginable-securities.pdf">Margin Financeable Securities</a></li-->
+    <li><a href="marginable-securities.php">Margin Financeable Securities</a></li>
+  </ul>
+</div>
+<table width="100%" cellspacing="2" cellpadding="0" border="0">
+  <tbody>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="Training_Academy_2.b.php"> DSE Training Academy </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="otc.php"> OTC Market </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="vision.php"> Vision &amp; Mission </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="dse_tower_progress.php"> DSE Tower Progress </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="dseglance.php"> DSE at a glance </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="press.php"> Press Release </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="picture_gallery.php"> Picture Gallery </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="ipo.php"> IPO </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="new.php"> Major Events </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="rightoffers.php"> Rights Offer Document </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="directlisting.php"> Direct Listing </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="cdbl.php"> CDBL </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="inquirydesk.php"> Inquiry Desk </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="complaintCell.php"> Complaint Cell </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="helpdesk_nrb.php"> Helpdesk for NRB </a></td>
+    </tr>
+  </tbody>
+</table>
+      </div>
+      <div id="RightBody" class="col-md-10 RightColmInner"> <span class="mobileleftmenu" onclick="openNav()">>></span> 
+        
+        <!-- Content Goes Here -->
+        <div class="row">
+          <div class="col-md-12 col-sm-12 col-xs-18" id="section-to-print">
+                                    <h2 class="BodyHead topBodyHead"> Company Name: <i>Advanced Chemical Industries PLC</i> 
+              <!-- <img alt="Company Information" title="Print Company Information" src="assets/images/printer_print.png" style="vertical-align:top;" class="pull-right img-responsive printCompany no-print" width="24"> --> 
+              
+              <a href="javascript: void(0);" onclick="PrintDiv();"><img alt="Company Information" title="Print Company Information" src="assets/images/printer_print.png" style="vertical-align:top;" class="pull-right img-responsive printCompany no-print" width="24"></a> </h2>
+            <div class="table-responsive">
+              <table class='table table-bordered background-white shares-table' id="company">
+                <tr class="alt">
+                  <th width="50%"><strong>Trading Code:</strong> ACI</th>
+                  <th width="50%"><strong>Scrip Code:</strong> 18455</th>
+                </tr>
+              </table>
+            </div>
+            
+            <!--<div class="ads-block">
+                                <script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+                                
+                                <ins class="adsbygoogle"
+                                     style="display:inline-block;width:728px;height:90px"
+                                     data-ad-client="ca-pub-2209070014716943"
+                                     data-ad-slot="7922174918"></ins>
+                                <script>
+                                (adsbygoogle = window.adsbygoogle || []).push({});
+                                </script>
+                            </div>--> 
+            <br/>
+            <div class="text-right"><strong>Figure in BDT</strong></div>
+            <h2 class="BodyHead topBodyHead">Market Information: <i>Jun 17, 2026</i></h2>
+            <div class="table-responsive">
+              <table class='table table-bordered background-white' id="company">
+                <tr>
+                  <th width="25%">Last Trading Price</th>
+                  <td width="25%">189.40</td>
+                  <th width="25%">Day's Range</th>
+                  <td width="25%">188.20 - 190.40</td>
+                </tr>
+                <tr class="alt">
+                  <th>Last Update</th>
+                  <td>2:40 PM</td>
+                  <th>52 Weeks' Moving Range</th>
+                  <td>165.10 - 231.00</td>
+                </tr>
+                <tr>
+                  <th>Change*</th>
+                  <td style="padding: 0; margin: 0;"><table width="100%">
+                      <tr>
+                        <td width="50%">-1</td>
+                        <td>-0.53%</td>
+                      </tr>
+                    </table></td>
+                  <th>Day's Trade (Nos.)</th>
+                  <td>557</td>
+                </tr>
+                <tr class="alt">
+                  <th>Yesterday's Closing Price</th>
+                  <td>190.40</td>
+                  <th>Day's Volume (Nos.)</th>
+                  <td>63,679</td>
+                </tr>
+                <tr>
+                  <th>Adjusted Opening Price</th>
+                  <td>190.40</td>
+                  <th>Day's Value (mn)  </th>
+                  <td>12.07</td>
+                </tr>
+                <tr class="alt">
+                  <th>Opening Price</th>
+                  <td>190.40</td>
+                  <th>Market Capitalization (mn)</th>
+                  <td>16,723.183</td>
+                </tr>
+                <tr>
+                  <th>Closing Price</th>
+                  <td>189.40</td>
+                  <th>Free Float Market Cap. (mn)</th>
+                  <td>7,477.765</td>
+                </tr>
+              </table>
+              <span class="footnote"> *Based on Yesterday's Closing Price and Last Trading Price.
+                            </span> </div>
+            <h2 class="BodyHead topBodyHead">Basic Information</h2>
+            <div class="table-responsive">
+              <table class='table table-bordered background-white' id="company">
+                <tr>
+                  <th width="25%">Authorized Capital (mn)</th>
+                  <td width="25%">3,000.00</td>
+                  <th width="25%">Debut Trading Date  </th>
+                  <td width="25%"></td>
+                </tr>
+                <tr class="alt">
+                  <th>Paid-up Capital (mn)</th>
+                  <td>878.32</td>
+                  <th>Type of Instrument  </th>
+                  <td>Equity</td>
+                </tr>
+                <tr>
+                  <th>Face/par Value</th>
+                  <td>10.0</td>
+                  <th>Market Lot</th>
+                  <td>1</td>
+                </tr>
+                <tr class="alt">
+                  <th>Total No. of Outstanding Securities</th>
+                  <td>87,831,843</td>
+                  <th>Sector</th>
+                  <td>Pharmaceuticals & Chemicals</td>
+                </tr>
+                <tr>
+                  <td colspan="4"><table class='table table-inner'>
+                      <tr>
+                        <th><span class="pull-right">Closing Price Graph:</span></th>
+                        <td><select onchange="show_graph(this.value)" class="form-control pull-left">
+                            <option value="">-Select Option-</option>
+                            <option value="ACI,1,price">1 month</option>
+                            <option value="ACI,3,price">3 months</option>
+                            <option value="ACI,6,price">6 months</option>
+                            <option value="ACI,9,price">9 months</option>
+                            <option value="ACI,12,price">1 year</option>
+                            <option value="ACI,24,price">2 years</option>
+                          </select></td>
+                        <th><span class="pull-right">Total Trade Graph:</span></th>
+                        <td><select onchange="show_graph(this.value)" class="form-control pull-left">
+                            <option value="">-Select Option-</option>
+                            <option value="ACI,1,trd">1 month</option>
+                            <option value="ACI,3,trd">3 months</option>
+                            <option value="ACI,6,trd">6 months</option>
+                            <option value="ACI,9,trd">9 months</option>
+                            <option value="ACI,12,trd">1 year</option>
+                            <option value="ACI,24,trd">2 years</option>
+                          </select></td>
+                        <th><span class="pull-right">Total Volume Graph:  </span></th>
+                        <td><select onchange="show_graph(this.value)" class="form-control pull-left">
+                            <option value="">-Select Option-</option>
+                            <option value="ACI,1,vol">1 month</option>
+                            <option value="ACI,3,vol">3 months</option>
+                            <option value="ACI,6,vol">6 months</option>
+                            <option value="ACI,9,vol">9 months</option>
+                            <option value="ACI,12,vol">1 year</option>
+                            <option value="ACI,24,vol">2 years</option>
+                          </select></td>
+                      </tr>
+                    </table></td>
+                </tr>
+              </table>
+            </div>
+            
+            <!--<div class="ads-block">
+                                <script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+                                
+                                <ins class="adsbygoogle"
+                                     style="display:inline-block;width:728px;height:90px"
+                                     data-ad-client="ca-pub-2209070014716943"
+                                     data-ad-slot="7922174918"></ins>
+                                <script>
+                                (adsbygoogle = window.adsbygoogle || []).push({});
+                                </script>
+                            </div>-->
+            
+            <h2 class="BodyHead topBodyHead row">
+              <div class="col-sm-6 pull-left">Last AGM held on: <i>28-12-2025</i></div>
+              <div class="col-sm-6 pull-right">For the year ended:
+                Jun 30, 2025              </div>
+            </h2>
+            <div class="table-responsive page-break">
+              <table class='table table-bordered background-white' id="company">
+                <tr class="alt">
+                  <th width="30%">Cash Dividend  </th>
+                  <td width="70%">25% 2025, 20% 2024, 40% 2023, 50% 2022, 65% 2021, 80% 2020,100% 2019, 115% 2018, 115% 2017, 115% 2016</td>
+                </tr>
+                <tr>
+                  <th>Bonus Issue (Stock Dividend)</th>
+                  <td>15% 2024, 5% 2022, 15% 2021, 10% 2020, 15% 2019, 3.50% 2018, 10% 2017, 10% 2016, 15% 2014, 20% 2013, 20% 2012, 20% 2011, 20% 2008, 20% 1997, 25% 1996, 100% 1994, 100% 1983.</td>
+                </tr>
+                <tr class="alt">
+                  <th>Right Issue</th>
+                  <td>1R:1(At Par) 1997</td>
+                </tr>
+                <tr>
+                  <th>Year End</th>
+                  <td>30-Jun</td>
+                </tr>
+                <tr class="alt">
+                  <th>Reserve & Surplus without OCI (mn)</th>
+                  <td>5,916.5</td>
+                </tr>
+                <tr>
+                  <th> <a class='ab1' href='company/comprehensive_income/Other-Comprehensive-Income.pdf'><strong>Other Comprehensive Income (OCI) (mn)</strong></a>                   </th>
+                  <td>0.0</td>
+                </tr>
+              </table>
+            </div>
+                        <h2 class="BodyHead topBodyHead page-break">Interim Financial Performance: <i>2026</i></h2>
+            <div class="table-responsive">
+              <table class='table table-bordered background-white' id="company">
+                <tr class="header">
+                  <td width="30%" rowspan="4" align="center" style="vertical-align: middle;">Particulars</td>
+                  <td colspan="6" align="center">Unaudited / Audited</td>
+                </tr>
+                <tr class="header">
+                  <td align="center">Q1</td>
+                  <td align="center">Q2</td>
+                  <td align="center">Half Yearly  </td>
+                  <td align="center">Q3</td>
+                  <td rowspan="3" align="center">9 Months<br>
+                    202603 </td>
+                  <td align="center">Annual</td>
+                </tr>
+                <tr class="header">
+                  <td align="center">Ending on</td>
+                  <td align="center">Ending on</td>
+                  <td rowspan="2" align="center">6 Months<br>
+                    202512</td>
+                  <td align="center">Ending on</td>
+                  <td align="center">Ending on</td>
+                </tr>
+                <tr class="header">
+                  <td align="center">202509</td>
+                  <td align="center">202512</td>
+                  <td align="center">202603</td>
+                  <td align="center"></td>
+                </tr>
+                <!--
+                <tr>
+                  <td>Turnover/Revenue (mn)</td>
+                  <td align="center">0</td>
+                  <td align="center">0</td>
+                  <td align="center">0                  <td align="center">0</td>
+                  <td align="center">0</td>
+                  <td align="center">-</td>
+                </tr>
+                <tr class="alt">
+                  <td>Profit from continuing operations (mn)</td>
+                  <td align="center">0</td>
+                  <td align="center">0</td>
+                  <td align="center">0</td>
+                  <td align="center">0</td>
+                  <td align="center">0</td>
+                  <td align="center">-</td>
+                </tr>
+                <tr>
+                  <td>Profit for the period (mn)</td>
+                  <td align="center">0</td>
+                  <td align="center">0</td>
+                  <td align="center">0</td>
+                  <td align="center">0</td>
+                  <td align="center">0</td>
+                  <td align="center">-</td>
+                </tr>
+                <tr class="alt">
+                  <td>Total Comprehensive Income for the period (mn)</td>
+                  <td align="center">0</td>
+                  <td align="center">0</td>
+                  <td align="center">0</td>
+                  <td align="center">0</td>
+                  <td align="center">0</td>
+                  <td align="center">-</td>
+                </tr>
+              -->
+                <tr class="header">
+                  <td colspan="7">Earnings Per Share (EPS)</td>
+                </tr>
+                <tr>
+                  <td>Basic</td>
+                  <td align="center">0.390</td>
+                  <td align="center">0.340</td>
+                  <td align="center">0.730</td>
+                  <td align="center">-4.910</td>
+                  <td align="center">-4.180</td>
+                  <td align="center">-</td>
+                </tr>
+                <tr class="alt">
+                  <td>Diluted*</td>
+                  <td align="center">-</td>
+                  <td align="center">-</td>
+                  <td align="center">-</td>
+                  <td align="center">-</td>
+                  <td align="center">-</td>
+                  <td align="center">-</td>
+                </tr>
+                <tr class="header">
+                  <td colspan="7">Earnings Per Share (EPS) - continuing operations</td>
+                </tr>
+                <tr>
+                  <td>Basic</td>
+                  <td align="center">0.390</td>
+                  <td align="center">0.340</td>
+                  <td align="center">0.730</td>
+                  <td align="center">-4.910</td>
+                  <td align="center">-4.180</td>
+                  <td align="center">-</td>
+                </tr>
+                <tr class="alt">
+                  <td>Diluted*</td>
+                  <td align="center">-</td>
+                  <td align="center">-</td>
+                  <td align="center">-</td>
+                  <td align="center">-</td>
+                  <td align="center">-</td>
+                  <td align="center">-</td>
+                </tr>
+                <tr>
+                  <td>Market price per share at period end  </td>
+                                    <td align="center">184.9</td>
+                  <td align="center">194.6</td>
+                  <td align="center">194.6</td>
+                  <td align="center">197.1</td>
+                  <td align="center">197.1</td>
+                  <td align="center">-</td>
+                </tr>
+              </table>
+              <span class="footnote">*As per BSEC Directive No. SEC/CMRRCD/2009-193/64, dated September 21, 2010. <br>
+              <font color="#0099FF"><strong> *Note: </strong> For detail financial statements, please visit company’s website. </font> </span> </div>
+                        <h2 class="BodyHead topBodyHead">Price Earnings (P/E) Ratio based on latest Un-audited Financial Statements  </h2>
+            <div class="table-responsive page-break">
+              <table class='table table-bordered background-white' id="company">
+                <tr>
+                  <td align="center" width="35%">Particulars</td>
+                  <td align="center">Jun 10, 2026</td><td align='center'>Jun 11, 2026</td><td align='center'>Jun 14, 2026</td><td align='center'>Jun 15, 2026</td><td align='center'>Jun 16, 2026</td><td align='center'>Jun 17, 2026</td>
+                </tr>
+                <tr class="alt">
+                  <td align="left">Current P/E Ratio using Basic EPS<br>
+                    (Continuing core operations)**</td>
+                  <td align="center">-</td><td align='center'>-</td><td align='center'>-</td><td align='center'>-</td><td align='center'>-</td><td align='center'>-</td>
+                </tr>
+                <tr>
+                  <td align="left">Current P/E ratio using Diluted EPS***<br>
+                    (Continuing core operation)</td>
+                  <td align="center">-</td><td align='center'>-</td><td align='center'>-</td><td align='center'>-</td><td align='center'>-</td><td align='center'>-</td>
+                </tr>
+                <tr class="alt">
+                  <td align="left">Trailing P/E Ratio</td>
+                  <td align="center">-77</td><td align='center'>-76.8</td><td align='center'>-77.73</td><td align='center'>-77.33</td><td align='center'>-77.09</td><td align='center'>-76.68</td>
+                </tr>
+              </table>
+            </div>
+                        <h2 class="BodyHead topBodyHead">Price Earnings (P/E) Ratio Based on latest Audited Financial Statements  </h2>
+            <div class="table-responsive">
+              <table class='table table-bordered background-white' id="company">
+                <tr>
+                  <td align="center" width="35%">Particulars</td>
+                  <td align="center">Jun 10, 2026</td><td align='center'>Jun 11, 2026</td><td align='center'>Jun 14, 2026</td><td align='center'>Jun 15, 2026</td><td align='center'>Jun 16, 2026</td><td align='center'>Jun 17, 2026</td>
+                </tr>
+                <tr class="alt">
+                  <td align="left">Current P/E Ratio using Basic EPS<br>
+                    (Continuing core operations)**</td>
+                  <td align="center"> n/a </td><td align='center'> n/a </td><td align='center'> n/a </td><td align='center'> n/a </td><td align='center'> n/a </td><td align='center'> n/a </td>
+                </tr>
+                <tr>
+                  <td align="left">Current P/E ratio using Diluted EPS***<br>
+                    (Continuing core operation)</td>
+                  <td align="center">-</td><td align='center'>-</td><td align='center'>-</td><td align='center'>-</td><td align='center'>-</td><td align='center'>-</td>
+                </tr>
+              </table>
+              <span class="footnote">** Usually refers to "<i>Continuing operations</i>".<br>
+              *** Calculated using bonus-adjusted number of shares as per BSEC Directive (not as per IAS 33 or BAS 33).</span>
+              </tr>
+            </div>
+            <h2 class="BodyHead topBodyHead page-break">Financial Performance as per Audited Financial Statements as per IFRS/IAS or BFRS/BAS</h2>
+            <div class="table-responsive">
+              <table class='table table-bordered background-white' id="company">
+                <tr class="shrink header">
+                  <td align="center" rowspan="3" style="vertical-align: middle;" colspan="2">Year</td>
+                  <td colspan="3" align="center">Earnings per share(EPS)</td>
+                  <td colspan="3" align="center"> EPS - Continuing Operations</td>
+                  <td colspan="3" rowspan="2" align="center">NAV Per Share</td>
+                  <td colspan="3" align="center">Profit/(Loss) and OCI  </td>
+                </tr>
+                <tr class="shrink header">
+                  <td colspan="2" align="center">Basic</td>
+                  <td rowspan="2" align="center">Diluted<br>
+                     </td>
+                  <td colspan="2" align="center">Basic</td>
+                  <td rowspan="2" align="center">Diluted<br>
+                     </td>
+                  <td rowspan="2" align="center">PCO*</td>
+                  <td rowspan="2" align="center">Profit for the year (mn)</td>
+                  <td rowspan="2" align="center">TCI*</td>
+                </tr>
+                <tr class="shrink header">
+                  <td align="center">Original</td>
+                  <td align="center">Restated</td>
+                  <td align="center">Original</td>
+                  <td align="center">Restated</td>
+                  <td align="center">Original</td>
+                  <td align="center">Restated</td>
+                  <td align="center">Diluted<br>
+                     </td>
+                </tr>
+                                <tr class="shrink alt"> 
+                  <!--<td align="center"><? echo $year;?></td>-->
+                  <td colspan="2" align="center">2021</td>                  <td align="center">-</td>
+                  <td align="center">-</td>
+                  <td align="center">-</td>
+                  <td align="center">5.50</td>
+                  <td align="center">4.78</td>
+                  <td align="center">-</td>
+                  <td align="center">162.65</td>
+                  <td align="center">141.43</td>
+                  <td align="center">-</td>
+                  <td align="center">347.17</td>
+                  <td align="center">347.17</td>
+                  <td align="center">347.17</td>
+                </tr>
+                                <tr class="shrink"> 
+                  <!--<td align="center"><? echo $year;?></td>-->
+                  <td colspan="2" align="center">2022</td>                  <td align="center">-</td>
+                  <td align="center">-</td>
+                  <td align="center">-</td>
+                  <td align="center">12.30</td>
+                  <td align="center">-</td>
+                  <td align="center">-</td>
+                  <td align="center">141.98</td>
+                  <td align="center">-</td>
+                  <td align="center">-</td>
+                  <td align="center">893.00</td>
+                  <td align="center">893.00</td>
+                  <td align="center">893.00</td>
+                </tr>
+                                <tr class="shrink alt"> 
+                  <!--<td align="center"><? echo $year;?></td>-->
+                  <td colspan="2" align="center">2023</td>                  <td align="center">-</td>
+                  <td align="center">-</td>
+                  <td align="center">-</td>
+                  <td align="center">-6.48</td>
+                  <td align="center">-</td>
+                  <td align="center">-</td>
+                  <td align="center">113.67</td>
+                  <td align="center">-</td>
+                  <td align="center">-</td>
+                  <td align="center">-493.96</td>
+                  <td align="center">-493.96</td>
+                  <td align="center">-493.96</td>
+                </tr>
+                                <tr class="shrink"> 
+                  <!--<td align="center"><? echo $year;?></td>-->
+                  <td colspan="2" align="center">2024</td>                  <td align="center">-</td>
+                  <td align="center">-</td>
+                  <td align="center">-</td>
+                  <td align="center">-18.25</td>
+                  <td align="center">-</td>
+                  <td align="center">-</td>
+                  <td align="center">91.17</td>
+                  <td align="center">-</td>
+                  <td align="center">-</td>
+                  <td align="center">-1394.67</td>
+                  <td align="center">-1394.67</td>
+                  <td align="center">-1394.67</td>
+                </tr>
+                                <tr class="shrink alt"> 
+                  <!--<td align="center"><? echo $year;?></td>-->
+                  <td colspan="2" align="center">2025</td>                  <td align="center">-</td>
+                  <td align="center">-</td>
+                  <td align="center">-</td>
+                  <td align="center">-7.40</td>
+                  <td align="center">-</td>
+                  <td align="center">-</td>
+                  <td align="center">91.64</td>
+                  <td align="center">-</td>
+                  <td align="center">-</td>
+                  <td align="center">-650.30</td>
+                  <td align="center">-650.30</td>
+                  <td align="center">-650.30</td>
+                </tr>
+                              </table>
+              <span class="footnote">PCO = Profit from Continuing Operations (mn)<br>
+              TCI = Total Comprehensive Income for the year (mn)</span> </div>
+            <h2 class="BodyHead topBodyHead">Financial Performance... (Continued)</h2>
+            <div class="table-responsive">
+              <table class='table table-bordered background-white' id="company">
+                <tr class="header">
+                  <td align="center" rowspan="4" style="vertical-align: middle;" colspan="2">Year</td>
+                  <td colspan="6" align="center">Year end Price Earnings (P/E) ratio</td>
+                  <td rowspan="4" align="center">Dividend in %*</td>
+                  <td rowspan="4" align="center">Dividend Yield in %</td>
+                </tr>
+                <tr class="header">
+                  <td colspan="3" align="center">Earnings per share(EPS)</td>
+                  <td colspan="3" align="center">EPS - Continuing Operations</td>
+                </tr>
+                <tr class="header">
+                  <td colspan="2" align="center">Using Basic EPS</td>
+                  <td rowspan="2" align="center">Using<br>
+                    Diluted EPS<br>
+                     </td>
+                  <td colspan="2" align="center">Using Basic EPS</td>
+                  <td rowspan="2" align="center">Using<br>
+                    Diluted EPS<br>
+                     </td>
+                </tr>
+                <tr class="header">
+                  <td align="center">Original</td>
+                  <td align="center">Restated<br>
+                     </td>
+                  <td align="center">Original</td>
+                  <td align="center">Restated<br>
+                     </td>
+                </tr>
+                                <tr class="shrink alt">
+                  <td colspan="2" align="center">2021</td>                  <td align="center">-</td>
+                  <td align="center">-</td>
+                  <td align="center">-</td>
+                  <td align="center">47.94</td>
+                  <td align="center">-</td>
+                  <td align="center">-</td>
+                  <td align="center">65%, 15%B</td>
+                  <td align="center">2.46</td>
+                </tr>
+                                <tr class="shrink">
+                  <td colspan="2" align="center">2022</td>                  <td align="center">-</td>
+                  <td align="center">-</td>
+                  <td align="center">-</td>
+                  <td align="center">50.42</td>
+                  <td align="center">-</td>
+                  <td align="center">-</td>
+                  <td align="center">50.00, 5%B</td>
+                  <td align="center">1.90</td>
+                </tr>
+                                <tr class="shrink alt">
+                  <td colspan="2" align="center">2023</td>                  <td align="center">-</td>
+                  <td align="center">-</td>
+                  <td align="center">-</td>
+                  <td align="center">-</td>
+                  <td align="center">-</td>
+                  <td align="center">-</td>
+                  <td align="center">40.00</td>
+                  <td align="center">1.54</td>
+                </tr>
+                                <tr class="shrink">
+                  <td colspan="2" align="center">2024</td>                  <td align="center">-</td>
+                  <td align="center">-</td>
+                  <td align="center">-</td>
+                  <td align="center">-</td>
+                  <td align="center">-</td>
+                  <td align="center">-</td>
+                  <td align="center">20.00, 15%B</td>
+                  <td align="center">1.51</td>
+                </tr>
+                                <tr class="shrink alt">
+                  <td colspan="2" align="center">2025</td>                  <td align="center">-</td>
+                  <td align="center">-</td>
+                  <td align="center">-</td>
+                  <td align="center">-</td>
+                  <td align="center">-</td>
+                  <td align="center">-</td>
+                  <td align="center">25.00</td>
+                  <td align="center">1.33</td>
+                </tr>
+                              </table>
+              <span class="footnote"> *B for bonus or stock dividend, otherwise cash.<br>
+              <strong>*Note: </strong>Price Earnings (P/E) Ratio has been calculated as per annual financial statements submitted by the listed securities by adopting uniform income year from July to June in compliance with the provisions of the Finance Act, 2015 and BSEC Directive No. SEC/SRMIC/2011/1240/445 dated April 27, 2016. For the first time adoption of the change in the financial year, listed companies, those year-ended on March, April, July, August, September, October and December, submitted their audited accounts by adding next few months or reducing few months and P/E has been calculated accordingly. </span>
+              <table class="table table-bordered background-white" id="company">
+                <tr>
+                  <th width="30%">Details of Financial Statement</th>
+                  <td><a target="_blank" href="https://www.aci-bd.com/financials/">https://www.aci-bd.com/financials/</a></td>
+                </tr>
+                <tr class="alt">
+                  <th width="30%">Price Sensitive Information</th>
+                  <td><a target="_blank" href="https://www.aci-bd.com/price-sensitive-information/">https://www.aci-bd.com/price-sensitive-information/</a></td>
+                </tr>
+              </table>
+            </div>
+            <h2 class="BodyHead topBodyHead page-break">Other Information of the Company</h2>
+            <div class="table-responsive">
+              <table class="table table-bordered background-white" id="company">
+                <tr>
+                  <td width="26%">Listing Year</td>
+                  <td width="74%">1976</td>
+                </tr>
+                <tr class="alt">
+                  <td>Market Category</td>
+                  <td>A</td>
+                </tr>
+                <tr>
+                  <td>Electronic Share</td>
+                  <td>Y</td>
+                </tr>
+                <tr class="alt">
+                  <td> Share Holding Percentage
+                    [as on Jun 30, 2025 (year ended)]</td>
+                  <td style="padding:0; margin:0;"><table width="100%" border="0" cellpadding="5" cellspacing="0">
+                      <tr>
+                        <td width="27%" align="center" style="border:hidden;">Sponsor/Director:<br>
+                          45.77</td>
+                        <td width="16%" align="center" style="border:hidden;">Govt:<br>
+                          0.00</td>
+                        <td width="20%" align="center" style="border:hidden;">Institute:<br>
+                          34.14</td>
+                        <td width="19%" align="center" style="border:hidden;">Foreign:<br>
+                          0.00</td>
+                        <td width="18%" align="center" style="border:hidden;">Public:<br>
+                          20.09</td>
+                      </tr>
+                    </table></td>
+                </tr>
+                                <tr class="">
+                  <td> Share Holding Percentage
+                    [as on Apr 30, 2026] </td>
+                  <td style="padding:0; margin:0;"><table width="100%" border="0" cellpadding="5" cellspacing="0">
+                      <tr>
+                        <td width="27%" align="center" style="border:hidden;">Sponsor/Director:<br>
+                          47.27</td>
+                        <td width="16%" align="center" style="border:hidden;">Govt:<br>
+                          0.00</td>
+                        <td width="20%" align="center" style="border:hidden;">Institute:<br>
+                          34.17</td>
+                        <td width="19%" align="center" style="border:hidden;">Foreign:<br>
+                          0.00</td>
+                        <td width="18%" align="center" style="border:hidden;">Public:<br>
+                          18.56</td>
+                      </tr>
+                    </table></td>
+                </tr>
+                                <tr class="alt">
+                  <td> Share Holding Percentage
+                    [as on May 31, 2026] </td>
+                  <td style="padding:0; margin:0;"><table width="100%" border="0" cellpadding="5" cellspacing="0">
+                      <tr>
+                        <td width="27%" align="center" style="border:hidden;">Sponsor/Director:<br>
+                          47.27</td>
+                        <td width="16%" align="center" style="border:hidden;">Govt:<br>
+                          0.00</td>
+                        <td width="20%" align="center" style="border:hidden;">Institute:<br>
+                          34.15</td>
+                        <td width="19%" align="center" style="border:hidden;">Foreign:<br>
+                          0.00</td>
+                        <td width="18%" align="center" style="border:hidden;">Public:<br>
+                          18.58</td>
+                      </tr>
+                    </table></td>
+                </tr>
+                                <tr>
+                  <td>Remarks</td>
+                  <td>-</td>
+                </tr>
+              </table>
+              <span class="footnote"><strong>Note:</strong> This is information for the concerned that total holdings of Sponsors/Directors of most of the listed securities have changed from the month of June, 2016 than that of earlier reporting mainly due to compliance of the regulation 2(1)(r) of the Dhaka Stock Exchange (Listing) Regulations, 2015 which reads QUOTE Sponsor means any person or institution who subscribes to the initial capital of a company or a mutual fund or a collective investment scheme. UNQUOTE</span> </div>
+            <h2 class="BodyHead topBodyHead">Corporate Performance at a glance  </h2>
+            <div class="table-responsive">
+              <table class="table table-bordered background-white" id="company">
+                <tr>
+                  <td colspan="2">Present Operational Status</td>
+                  <td width="65%" align="right">Active</td>
+                </tr>
+                <tr class="header">
+                  <td colspan="3">Present Loan Status as on June 30, 2025</td>
+                </tr>
+                <tr>
+                  <td rowspan="2" width="3%">&nbsp;</td>
+                  <td width="32%">Short-term loan (mn) </td>
+                  <td align="right">648.2</td>
+                </tr>
+                <tr class="alt">
+                  <td>Long-term loan (mn) </td>
+                  <td align="right">5548.42</td>
+                </tr>
+                <tr>
+                  <td colspan="2">Latest Dividend Status (%)</td>
+                  <td align="right">25.00 for 2025</td>
+                </tr>
+                <tr class="header">
+                  <td colspan="3">Latest Credit Rating Status</td>
+                </tr>
+                <tr>
+                  <td rowspan="2" width="3%">&nbsp;</td>
+                  <td width="32%">Short-term</td>
+                  <td align="right"></td>
+                </tr>
+                <tr class="alt">
+                  <td>Long-term</td>
+                  <td align="right"></td>
+                </tr>
+                                <tr class=''>
+                  <td colspan="2">OTC/Delisting/Relisting</td>
+                  <td align="right"></td>
+                </tr>
+              </table>
+            </div>
+            <h2 class="BodyHead topBodyHead">Address of the Company</h2>
+            <div class="table-responsive">
+              <table class="table table-bordered background-white" id="company">
+                <tr>
+                  <td width="10%" rowspan="2">Address</td>
+                  <td width="10%">Head Office</td>
+                  <td width="80%">ACI Centre, 245 Tejgaon I/A, Dhaka - 1208</td>
+                </tr>
+                <tr>
+                  <td width="10%">Factory</td>
+                  <td width="80%">7 Hajiganj Road, Godnail, Narayanganj</td>
+                </tr>
+                <tr class="alt">
+                  <td colspan="2">Contact Phone</td>
+                  <td>02226605101, 02226605133</td>
+                </tr>
+                <tr>
+                  <td colspan="2">Fax</td>
+                  <td>02226605119</td>
+                </tr>
+                <tr class="alt">
+                  <td colspan="2">E-mail</td>
+                  <td>info@aci-bd.com</td>
+                </tr>
+                <tr>
+                  <td colspan="2">Web Address</td>
+                  <td><a class ='ab1' target="_blank" href="http://www.aci-bd.com"> http://www.aci-bd.com</a></td>
+                </tr>
+                <tr class="alt">
+                  <td colspan="2">Company Secretary Name</td>
+                  <td>Mr. Mohammad Mostafizur Rahman</td>
+                </tr>
+                <tr>
+                  <td colspan="2">Cell No.</td>
+                  <td>+88 01708467600</td>
+                </tr>
+                <tr class="alt">
+                  <td colspan="2">Telephone No.</td>
+                  <td>02226605101</td>
+                </tr>
+                <tr>
+                  <td colspan="2">E-mail</td>
+                  <td>mostafizur.rahman@aci-bd.com</td>
+                </tr>
+              </table>
+            </div>
+            <div class="table-responsive">
+              <table width="100%" border="0" cellpadding="5" cellspacing="0">
+                <tr>
+                  <td></td>
+                </tr>
+                <tr>
+                  <td><strong>Note:</strong> (i) All dynamic information of this page are only valid for <i>Public</i> and <i>Debt</i> board. (ii) Annual/ Audited figures are updated after AGM except for ‘Total No. of Outstanding Securities’ which is updated on record date.<br/>
+                    <strong>Disclaimer:</strong> This page is now under updating process. If any anomalies are found , please inform us (phone: +880241040189-200, +8809666702070, Ext- 1546). </td>
+                </tr>
+              </table>
+            </div>
+                                  </div>
+        </div>
+        <br/>
+        <br/>
+        <style type="text/css" media="print">
+
+.main-signature{
+        display: none;
+    }
+
+</style>
+<div class="main-signature">
+	<div style="text-align:center;" class="signature-class"> 
+		<!-- <img height=53 src="assets/images/dse.gif" width=363 border=0  class="img-responsive center-block" style="margin-top: 20px;"><BR/> -->
+		<img height=53 src="assets/images/dse-plc.gif" width=340 border=0  class="img-responsive center-block" style="margin-top: 20px;"><BR/>
+		DSE Tower, Plot # 46, Road # 21, Nikunja-2, Dhaka-1229, Bangladesh<BR>
+		Phone: +88-02-41040189-200, FAX: +88-02-41040096<BR>
+		Email: <a class='ab1' href="mailto:info@dse.com.bd">info@dse.com.bd</A>, 
+		Web: <a class='ab1' href="http://www.dsebd.org/">http://www.dsebd.org/</A><BR/>&nbsp;
+	</div>
+</div>      </div>
+    </div>
+  </section>
+  <div class="clearfix"></div>
+</div>
+<!--Containerbox End-->
+
+<style type="text/css" media="print">
+
+.containerFot, .containerFotMobile{
+        display: none;
+    }
+
+</style>
+
+<div class="containerFot">
+	<footer>
+		<div class="footerBottom row al-li">
+			<div class="col-2"><a href="disclaimer.htm">Disclaimer</a></div>
+			<div class="col-8">
+				<ul>
+					<li><a href="index.php">Home</a></li>
+					<li><a href="download.php">Download</a></li>
+					<li><a href="data_archive.php">Data Archives</a></li>
+					<li><a href="career.php">Career at DSE</a></li>
+					<li><a href="dse_faq.php">FAQ</a></li>
+					<li><a href="feedback.php">WUF</a></li>
+					<li><a href="sitemap.php">Site Map</a></li>
+					<li><a href="ose.php">Link</a></li>
+				</ul>
+				<p><a href="copyright.htm"><font size="3">&copy;</font> Dhaka Stock Exchange 2020</a></p>
+			<!--	<p>Powered by <a href="http://www.bol-online.com" target="_blank"> Bangladesh Online</a>, a division of Bangladesh Export Import Company Ltd.</p>  -->
+			</div>
+			<div class="col-2"><a href="termsacond.htm">Terms & Condition</a></div>
+		</div>
+	</footer>
+	<div class="clearfix"></div>
+</div>
+
+<div class="containerFotMobile">
+	<footer>
+		<div class="footerBottom row">
+			<div class="col-md-2 col-6"><a href="disclaimer.htm">Disclaimer</a></div>
+			<div class="col-md-2 col-6"><a href="termsacond.htm">Terms &amp; Condition</a></div>
+			<div class="col-md-8 col-12">
+				<ul>
+					<li><a href="index.php">Home</a></li>
+					<li><a href="download.php">Download</a></li>
+					<li><a href="data_archive.php">Data Archives</a></li>
+					<li><a href="career.php">Career at DSE</a></li>
+					<li><a href="dse_faq.php">FAQ</a></li>
+					<li><a href="feedback.php">WUF</a></li>
+					<li><a href="sitemap.php">Site Map</a></li>
+					<li><a href="ose.php">Link</a></li>
+				</ul>
+				
+      			<p><a href="copyright.htm"><font size="3">&copy;</font> Dhaka Stock Exchange 2020</a></p>
+				<!--	<p>Powered by <a href="http://www.bol-online.com" target="_blank"> Bangladesh Online</a>, a division of Bangladesh Export Import Company Ltd.</p> -->
+			</div>
+		</div>
+	</footer>
+	<div class="clearfix"></div>
+</div>
+<link href="assets/lib/scroll/perfect-scrollbar.css" rel="stylesheet">
+
+<!-- <script defer src="assets/js/jquery.min.js"></script> -->
+<!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.0/jquery.min.js" integrity="sha512-b6lGn9+1aD2DgwZXuSY4BhhdrDURVzu7f/PASu4H1i5+CRpEalOOz/HNhgmxZTK9lObM1Q7ZG9jONPYz8klIMg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script> -->
+
+<!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script> -->
+<script src="assets/update/jquery.min.js"></script>
+
+<script defer type="text/javascript" src="assets/js/jquery-ui.js"></script>
+<!-- <script defer type="text/javascript" src="assets/js/bootstrap.js"></script> -->
+
+<!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.1.3/js/bootstrap.min.js" integrity="sha512-OvBgP9A2JBgiRad/mM36mkzXSXaJE9BEIENnVEmeZdITvwT09xnxLtT4twkCa8m/loMbPHsvPl0T8lRGVBwjlQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script> -->
+<script src="assets/update/bootstrap.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+
+<script defer type="text/javascript" src="assets/js/tab.js"></script>
+<script defer src="assets/lib/scroll/perfect-scrollbar.min.js"></script>
+<script defer type="text/javascript" src="assets/js/jquery.floatThead.min.js"></script>
+<script defer type="text/javascript" src="assets/js/jquery.dataTables.min.js"></script>
+<script defer type="text/javascript" src="assets/js/custom.js"></script>
+
+<script type="text/javascript">
+	// $('.carousel').carousel({
+	//   	interval: 3000
+	// });
+
+	$('.collapse-sub').on('shown.bs.collapse-sub', function (e) {
+  		$('.collapse-sub').not(this).removeClass('in');
+	});
+
+	$('[data-toggle=collapse-sub]').click(function (e) {
+	  	$('[data-toggle=collapse-sub]').parent('li').removeClass('active');
+	  	$(this).parent('li').toggleClass('active');
+	});
+
+  	$(function() {
+    	$('#description').perfectScrollbar();
+  	
+  		$(".profiles").find(".tab").hide();
+		$(".profiles").find(".tab").first().show();
+		$(".profiles").find(".tabs li").first().find("a").addClass("active");
+
+		$(".profiles").find(".tabs").find("a").click(function(){
+		    tab = $(this).attr("href");
+		    $(".profiles").find(".tab").hide();
+		    $(".profiles").find(".tabs").find("a").removeClass("active");
+		    $(tab).show();
+		    $(this).addClass("active");
+		    return false;
+		});
+
+		var TradingCode = [];
+		$.get("ajax/suggestList.php", { "suggestType" : "tc" }, function(ret){ 
+			TradingCode = JSON.parse(ret);
+			$( ".textCompany" ).autocomplete({
+				source: TradingCode/*function( request, response ) {
+						var matcher = new RegExp( "^" + $.ui.autocomplete.escapeRegex( request.term ), "i" );
+						response( $.grep( TradingCode, function( item ){
+							return matcher.test( item.label );
+						}) )*/
+			});
+		});
+
+		var TrecHolder = [];
+		$.get("ajax/suggestList.php", { "suggestType" : "th" }, function(ret){ 
+			TrecHolder = JSON.parse(ret);
+			$( ".textTRECHolder" ).autocomplete({
+				source: TrecHolder
+			});
+		});
+	});
+
+	function openNav() {
+		document.getElementById("mySidenav").style.width = "250px";
+	    document.getElementById("RightBody").style.marginLeft = "250px";
+	}
+
+	function closeNav() {
+	    document.getElementById("mySidenav").style.width = "0";
+	    document.getElementById("RightBody").style.marginLeft= "0";
+	}
+
+	function chkform() {
+		if(document.form.name.value == "") {
+	   		alert("Please Enter Specific company symbol or company name");
+	   		document.form.name.focus();
+	   		return false;
+		}
+
+
+	}
+
+(function($){
+	$(document).ready(function(){
+
+		$(".dropdown-submenu").on("click", function(e){
+			//e.preventDefault();
+			e.stopPropagation();
+
+			$(this).toggleClass('open');
+			var dropdown = $(this).find('.dropdown-toggle');
+			if (dropdown.attr('aria-expanded')) {
+				dropdown.removeAttr('aria-expanded');
+			} else {
+				dropdown.attr('aria-expanded', true);
+			};
+		});
+	});
+})(jQuery);
+</script></body>
+</html><script>
+    $(function(){
+        $('[data-toggle="tooltip"]').tooltip();    
+
+        // $(".printCompany").on("click", function(){
+        //     window.print();
+        // })
+    })
+
+    function PrintDiv() {    
+        var divToPrint = document.getElementById('section-to-print');
+        var popupWin = window.open('', '_blank', 'width=900,height=750');
+        popupWin.document.open();
+        popupWin.document.write('<html><head><link href="assets/css/printDiv.css" rel="stylesheet" type="text/css"/><style>body, table td, table th{ font-size: 13px; }</style></head><body onload="window.print()">' + divToPrint.innerHTML + '</html>');
+        popupWin.document.close();
+    }
+    calculateRightBody();
+</script>

--- a/tests/fixtures/dse_market_statistics.html
+++ b/tests/fixtures/dse_market_statistics.html
@@ -1,0 +1,300 @@
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<title>DSE Market Statistics</title>
+<style>
+  .blink_me {
+  animation: blinker 2s linear infinite;
+}
+
+@keyframes blinker {  
+  50% { opacity: 0; }
+}
+
+ </style>
+
+</head>
+
+<body style="padding-bottom: 200px !important;">
+<table valign="top" width="80%" border="0" cellspacing="0" cellpadding="0" bgcolor="#FFFFFF" >
+<tr>
+  <!-- <td colspan="2" align="center">
+ 
+             Google Adsense ad code 
+           <script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+ LeaderboardLarge 
+<ins class="adsbygoogle"
+     style="display:inline-block;width:970px;height:90px"
+     data-ad-client="ca-pub-2209070014716943"
+     data-ad-slot="8843518118"></ins>
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({});
+</script>
+      End of Google Adsense ad code 
+     
+		 
+	 	
+						  
+  </td> -->
+  </tr>
+  <tr> 
+   
+   
+   
+   
+    <td align="center" width="70%"> <blockquote>
+    
+	<!--   
+	   <table width="100%" border="1" align="center"  cellspacing="0" cellpadding="5" bordercolor="#000000" >
+          <tr> 
+            <td width="100%" align=center bordercolor="#663366" bgcolor="#FFFFCC"  class="button"> 
+              <blockquote>
+                <div align="justify"> <font color="#990033"><span class="blink_me"><b><font color="#003333">Notice:</font> 
+                  </b></span></font> <font color="#006600" size="3"><em><font color="#000000">"Detailed 
+                  DSE Market Statistics or End of Day (EOD) data will be available 
+                  on subscription basis. Please contact - wasi.azam@dse.com.bd 
+                  (for information) and rezaur.rahman@dse.com.bd (for technical 
+                  assistance)"</font></em><strong><em><font color="#000000"> </font></em></strong></font> 
+                </div>
+              </blockquote></td>
+                          </tr>
+                          
+                        </table>
+	   		-->  
+		  
+		  <br>
+      </blockquote>
+      
+	        <code>
+                <pre>                      DHAKA STOCK EXCHANGE PLC.
+
+                  TODAY'S SHARE MARKET : 2026-06-17
+                  =================================
+
+
+All Category
+
+    ISSUES ADVANCED                 :                    182
+    ISSUES DECLINED                 :                    158
+    ISSUES UNCHANGED                :                     54
+    TOTAL ISSUES TRADED             :                    394
+
+
+A Category
+
+    ISSUES ADVANCED                 :                     74
+    ISSUES DECLINED                 :                     94
+    ISSUES UNCHANGED                :                     33
+    TOTAL ISSUES TRADED             :                    201
+
+
+B Category
+
+    ISSUES ADVANCED                 :                     44
+    ISSUES DECLINED                 :                     27
+    ISSUES UNCHANGED                :                      4
+    TOTAL ISSUES TRADED             :                     75
+
+
+N Category
+
+    ISSUES ADVANCED                 :                      0
+    ISSUES DECLINED                 :                      0
+    ISSUES UNCHANGED                :                      0
+    TOTAL ISSUES TRADED             :                      0
+
+
+Z Category
+
+    ISSUES ADVANCED                 :                     64
+    ISSUES DECLINED                 :                     37
+    ISSUES UNCHANGED                :                     17
+    TOTAL ISSUES TRADED             :                    118
+
+
+------------------------------------------------------------
+MUTUAL FUND (MF)
+
+    ISSUES ADVANCED                 :                      5
+    ISSUES DECLINED                 :                      8
+    ISSUES UNCHANGED                :                     21
+    TOTAL ISSUES TRADED             :                     34
+
+
+CORPORATE BOND (CB)
+
+    ISSUES ADVANCED                 :                      2
+    ISSUES DECLINED                 :                      3
+    ISSUES UNCHANGED                :                      0
+    TOTAL ISSUES TRADED             :                      5
+
+
+Govt. Sec (G-Sec)
+
+    ISSUES ADVANCED                 :                      3
+    ISSUES DECLINED                 :                      2
+    ISSUES UNCHANGED                :                      0
+    TOTAL ISSUES TRADED             :                      5
+
+
+------------------------------------------------------------
+TOTAL TRANSACTIONS
+
+    A. NO. OF TRADES                :                 285669
+    B. VOLUME(Nos.)                 :              436237110
+    C. VALUE(Tk)                    :         12112954699.70
+
+
+
+MARKET CAPITALISATION
+
+    1. EQUITY                       			:       3515860823036.60
+    2. MUTUAL FUND                  			:         25809561691.00
+    3. DEBT SECURITIES					:       3356517287112.10
+    TOTAL                           			:       6898187671839.70
+
+
+
+
+                    PRICES IN BLOCK TRANSACTIONS : 2026-06-17
+                    =========================================
+
+Instr Code    Max Price    Min Price    Trades    Quantity    Value(In Mn)
+
+ACFL              24.50        24.50         1       75000           1.837
+ADNTEL            67.10        67.10         1       14981           1.005
+ALIF               5.00         5.00         1      100000           0.500
+AMANFEED          31.80        31.60         9      699085          22.143
+ARGONDENIM        17.90        17.90         1       50000           0.895
+ASIAINS           46.80        46.80         1       16900           0.791
+ASIATICLAB       132.70       108.80         3       96930          11.017
+BNICL            112.80       112.80         1       17730           2.000
+BPPL              22.50        22.50         1      170500           3.836
+BRACBANK          59.50        59.50         1       84000           4.998
+CENTRALINS        45.20        45.20         1       11500           0.520
+CITYGENINS       106.80        96.50         5      229298          23.021
+CLICL             59.00        59.00         1       28000           1.652
+COPPERTECH        30.10        25.00         2      263500           7.299
+DAFODILCOM       155.40       150.10         8       59049           9.063
+DELTALIFE         90.10        90.10         1       20000           1.802
+DOMINAGE          75.30        73.00         3      363201          26.692
+DOREENPWR         34.40        34.40         1       85200           2.931
+EBL               25.00        24.80         4      417687          10.412
+EIL               32.70        32.70         1       30000           0.981
+GBBPOWER           8.20         8.20         1      221900           1.820
+GENEXIL           36.10        36.10         1      100000           3.610
+GOLDENSON         15.10        15.10         1      100000           1.510
+IBP               17.00        17.00         1       40555           0.689
+INTRACO           20.70        20.70         1      100500           2.080
+IPDC              26.00        26.00         1      320000           8.320
+ISLAMIINS         59.80        50.00         4      399465          22.976
+KAY&amp;QUE          400.20       400.20         1        1800           0.720
+KBPPWBIL          42.50        42.20         2       62000           2.620
+LHB               52.30        52.30         1       10000           0.523
+LOVELLO           70.00        70.00         1       52395           3.668
+MAKSONSPIN         5.60         5.60         1      515000           2.884
+MALEKSPIN         31.00        31.00         1       50000           1.550
+MERCINS           41.00        41.00         1      127500           5.228
+MLDYEING           9.90         9.90         1      236973           2.346
+NFML              20.00        19.00         5      852827          16.349
+PADMAOIL         186.00       186.00         1        3451           0.642
+PARAMOUNT         68.00        68.00         1       18700           1.272
+PRAGATIINS        82.20        82.20         1       10000           0.822
+PRIMEBANK         30.30        30.00        10    10208717         306.270
+PRIMELIFE         49.10        49.10         1       19500           0.957
+PURABIGEN         35.50        32.00         6      337854          11.235
+SAIHAMCOT         22.10        22.10         1       31000           0.685
+SAPORTL           63.20        63.20         1      100000           6.320
+SEAPEARL          33.10        33.10         1       32500           1.076
+SHAHJABANK        15.30        15.30         2     1110622          16.993
+SHASHADNIM        24.50        24.50         2       86000           2.107
+SINGERBD          85.10        85.00         2       44591           3.791
+STANDBANKL         4.40         4.40         1     1100000           4.840
+SUMITPOWER        14.80        14.80         1       50000           0.740
+SUNLIFEINS        72.00        72.00         1        7000           0.504
+TILIL             56.90        56.90         1        9000           0.512
+TRUSTBANK         16.20        16.20         1       31100           0.504
+UTTARABANK        21.80        21.80         1       26437           0.576
+                                        ------    --------    ------------
+                                           106    19249948         570.133
+
+Total number of scrips traded in Block            =   54
+
+
+
+
+</pre>
+            </code>    </td>
+<td valign="top">
+
+
+<!--/* OpenX Asynchronous JavaScript tag */
+
+
+<div id="538628974_300x250" style="width:300px;height:250px;margin:0;padding:0">
+  <noscript><iframe id="e37581d824" name="e37581d824" src="//raiseit-d.openx.net/w/1.0/afr?auid=538628974&cb={random}" frameborder="0" scrolling="no" width="300" height="250"><a href="//raiseit-d.openx.net/w/1.0/rc?cs=e37581d824&cb={random}" ><img src="//raiseit-d.openx.net/w/1.0/ai?auid=538628974&cs=e37581d824&cb={random}" border="0" alt=""></a></iframe></noscript>
+</div>
+<script type="text/javascript">
+  var OX_ads = OX_ads || [];
+  OX_ads.push({
+     slot_id: "538628974_300x250",
+     auid: "538628974"
+  });
+</script>
+
+<script type="text/javascript" src="//raiseit-d.openx.net/w/1.0/jstag"></script>-->
+
+<!-- <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+Medium Rectangle 
+<ins class="adsbygoogle"
+     style="display:inline-table;width:300px;height:250px"
+     data-ad-client="ca-pub-2209070014716943"
+     data-ad-slot="4539494913"></ins>
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({});
+</script>       
+                 -->
+
+<!-- <script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+ Portrait 
+<ins class="adsbygoogle"
+     style="display:inline-block;width:300px;height:1050px"
+     data-ad-client="ca-pub-2209070014716943"
+     data-ad-slot="7156224513"></ins>
+<script>
+(adsbygoogle = window.adsbygoogle || []).push({});
+</script> -->
+
+
+</td>
+</tr>
+<tr>
+  <td align="justify" style="padding-left:25px;">
+   
+
+<b>Note:</b>
+<ul>
+<li>Issues Advanced; Issues declined; Issues Unchanged in this market summary file are based on CP (closing price) whereas the same are calculated on DSE website based on LTP (last trade price) during trading session.</li>
+<li>CP is defined as "The closing price for a security shall be determined as per the weighted average price of all the trades in the last 30 (thirty) minutes before the closing session. If there is no trade during that specified time, the weighted average price of maximum 20 (twenty) number of trades preceding the above 30 (thirty) minutes shall be taken for determination of closing price".</li>
+</ul>
+
+<p>&nbsp;</p>
+
+  </td>
+  <td valign="top">&nbsp;</td>
+</tr>
+</table>
+
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+  ga('create', 'UA-70465433-1', 'auto');
+  ga('send', 'pageview');
+
+</script></body>
+</html>

--- a/tests/fixtures/dse_news_aci.html
+++ b/tests/fixtures/dse_news_aci.html
@@ -1,0 +1,8051 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+	<title>News Archive | Dhaka Stock Exchange</title>
+ 	<meta name="description" content="">
+ 	<meta name="Author" content="Dhaka Stock Exchange" />	
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta http-equiv="X-UA-Compatible" content="IE=10; IE=9; IE=8; IE=7; IE=EDGE" />
+	<meta http-equiv="refresh" content="300;">
+	<link href="assets/imgs/favicon.ico" rel="shortcut icon">
+
+	<!-- <link rel="dns-prefetch" href="https://cdnjs.cloudflare.com/" > -->
+	<link rel="dns-prefetch" href="https://www.googletagmanager.com" >
+
+	<link async="async" href="assets/update/css/layout.css?v=0.1" rel="stylesheet" type="text/css">
+	<link async="async" href="assets/update/css/layout-responsive.css?v=0.1" rel="stylesheet" type="text/css">
+
+	<!-- <link async="async" href="assets/css/bootstrap.css" rel="stylesheet" type="text/css"> -->
+	<!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.1.3/css/bootstrap.min.css" integrity="sha512-GQGU0fMMi238uA+a/bdWJfpUGKUkBdgfFdgBm72SUQ6BeyWjoY/ton0tEjH+OSH9iP4Dfh+7HM0I9f5eR0L/4w==" crossorigin="anonymous" referrerpolicy="no-referrer" /> -->
+	<link rel="stylesheet" href="assets/update/bootstrap.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
+
+	<link async="async" href="assets/css/carousel.css" rel="stylesheet" type="text/css">
+	<link async="async" href="assets/css/font-awesome.css" rel="stylesheet" type="text/css"/>
+    <link async="async" href="assets/css/rotate-wheel.css" rel="stylesheet" type="text/css"/>
+    <link async="async" href="assets/css/jquery-ui.css" rel="stylesheet" type="text/css"/>
+
+    <!--custom Link -->
+    <link async="async" href="assets/css/custom-training.css" rel="stylesheet" type="text/css"/>
+
+    <!-- <script async="async" type="text/javascript" src="assets/js/dygraph-combined.js"></script> -->
+
+	<!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/dygraph/2.1.0/dygraph.min.js" integrity="sha512-opAQpVko4oSCRtt9X4IgpmRkINW9JFIV3An2bZWeFwbsVvDxEkl4TEDiQ2vyhO2TDWfk/lC+0L1dzC5FxKFeJw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script> -->
+	<script src="assets/update/dygraph.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+
+    <link async="async" href="assets/css/jquery.dataTables.min.css" rel="stylesheet" type="text/css">
+	
+	<!-- Global site tag (gtag.js) - Google Analytics -->
+	<script async src="https://www.googletagmanager.com/gtag/js?id=UA-70465433-1"></script>
+	<script>
+	  window.dataLayer = window.dataLayer || [];
+	  function gtag(){dataLayer.push(arguments);}
+	  gtag('js', new Date());
+
+	  gtag('config', 'UA-70465433-1');
+	</script>
+	<style type="text/css">
+		body {
+			font-family: Arial,sans-serif !important;
+			font-size: 12px !important;
+			--bs-body-line-height : 1.42857143 !important; /*Add 29-12-2021*/
+		}
+		.btn-primary {
+		    color: #fff;
+		    background-color: #337ab7 !important;
+		    border-color: #337ab7 !important;
+		}
+		.btn-primary:hover{
+		    background-color: #286090 !important;
+		    border-color: #286090 !important;
+		}
+		
+		.gray {
+			/*background: none !important;*/
+			display: flex !important;
+			text-align: justify;
+		}
+		.pre-footer .btn {
+			font-size: 11px;
+		}
+				
+		.nav-tabs .nav-item.show .nav-link, .nav-tabs .nav-link{
+			background-color: #EEEEEE !important;
+		}
+		.nav-tabs .nav-item.show .nav-link, .nav-tabs .nav-link.active{
+			background-color: #fff !important;
+		}
+
+		#RightBody {
+		    padding: 6px 5px 0 5px !important; /*Add 29-12-2021*/
+		    position :relative !important;
+		}
+		.signature-class {
+		    margin: 0 -5px !important; /*Add 29-12-2021*/
+		}
+		.main-signature {
+			margin-top: 160px;
+		}
+
+		table{
+			color: #5a5a5a !important; /*Add 29-12-2021*/
+		}
+
+		.form-control {
+		    padding : 0.25rem .75rem !important;
+		    font-size: 14px  !important;
+		}
+
+		.table>:not(:first-child) {
+		    border-top: 0 !important;
+		}
+		.background-yellow {
+		    background-color: #ff9 !important;
+		}
+		.category li a {
+		    color: #337ab7 !important;
+		}
+		.bg-danger {
+		    background-color: #f2dede !important;
+		}
+		.txt-al-l {
+			text-align: left !important;
+		}
+		.ml-10 {
+    		margin-left: 10%;
+		}
+		.pd-10 {
+			padding: 10px;
+		}
+        .tpb-10 div {
+            padding-bottom: 10px;
+        }
+		.pdt-10 {
+			padding-top: 10px;
+		}
+		.glance-table {
+			width: 80%; 
+			margin: auto;
+		}
+
+		@media (max-width: 768px){
+			.RightColmInner  {
+			    width: 100% !important;
+			}
+			.RightColmInner .list-group {
+			    margin-bottom: 50px;
+			}
+			.mb-50 {
+			    margin-bottom: 50px;
+			}
+			.wd-100 {
+				width: 100%;
+			}
+			.main-signature {
+				margin-top: 200px!important;
+			}
+			.brd {
+				border: 1px #ddd solid !important;
+			}
+			.glance-table {
+				width: 100% !important; 
+				margin: auto !important;
+			}
+			.ifra {
+				width: none;
+				height: none;
+			}
+			.wh-sp-nw-mobile {
+				white-space: nowrap;
+			}
+
+		}
+
+		@media (min-width: 768px){
+			.transfer-procedure dt {
+			    margin-left: 35px !important;
+			    padding-bottom: 0px !important;
+			}
+			.ifra {
+				width: 640px;
+				height: 385px;
+			}
+		}
+		.transfer-procedure h5 {
+			font-size: 14px !important;
+		}
+
+		.center-block {
+		    display: block;
+		    margin-right: auto;
+		    margin-left: auto;
+		}
+		.al-li{
+			--bs-gutter-x: 0 !important;
+		}
+		.cl-pr .table>:not(caption)>*>* {
+		    border-bottom-width: 0px !important;
+		}
+		.data-arc .data-archive-block {
+		    padding-bottom: 20px !important;
+     		border-bottom: none !important; 
+
+		}
+		.data-arc .btn-sm {
+		    font-size: 12px !important;
+		}
+
+		.rules-regulation li {
+			padding-right: 10px;
+			padding-left: 10px;
+		}
+		.pd-lr-0 li {
+			padding-right: 0px !important;
+			padding-left: 0px !important;
+		}
+		.list-group-item.active {
+		    z-index: 2;
+		    color: #fff;
+		    background-color: #337ab7;
+		    border-color: #337ab7;
+		}
+		.list-group-item {
+		    color: #555;
+		}
+		.tx-al-st {
+			text-align: start !important;
+		}
+		.training-heading a {
+		    color: #ffffff !important;
+		    text-shadow: black 0.5em 0.5em 0.2em !important;
+		    line-height: 4 !important;
+		}
+		.marquee-heading a {
+		    color: white !important;
+		    text-shadow: black 0.4em 0.4em 0.15em !important;
+		}
+		.mr-0 {
+			margin: 0 !important;
+		}
+		.pdb-10 {
+			padding-bottom: 10px;
+		}
+
+		.list li {
+		    padding-right: 0px !important; 
+		    padding-left: 0px !important;
+		}
+		.select-color {
+		    color: #337ab7 !important;
+		}
+		.pdb-5 {
+			padding-bottom: 5px;
+		}
+		.txt-left {
+			text-align: left !important;
+		}
+
+		/*For faq and career start*/
+        .newaccordion .panel {
+            margin-bottom: 20px;
+            background-color: #fff;
+            border: 1px solid #ddd;
+            box-shadow: 0 1px 1px rgba(0,0,0,.05);
+        }
+        .newaccordion .panel h2 {
+            margin-top: 20px;
+        }
+        .newaccordion .card {
+            border: none !important;
+        }
+        .newaccordion .btn-link {
+            color: #0d6efd;
+            text-decoration: none;
+        }
+        .newaccordion .card-header {
+            margin-bottom: 5px !important;
+            border-radius: 25px !important;
+        }
+        .f-14{
+        	font-size: 14px !important;
+        }
+		/*For faq and career end*/
+        .f-18{
+        	font-size: 18px !important;
+        }
+		/*For dse dept start*/
+        .dse-dept .panel-title {
+            padding: 10px !important;
+        }
+        .dse-dept .panel-title a {
+            color: #fff !important;
+        }
+		/*For dse dept start*/
+
+		.panel-body-dept {
+		    padding-top: 0 !important;
+		    padding-bottom: 0 !important;
+		    padding-left: 6px !important;
+		    padding-right: 6px !important;
+		}
+		.dept-collapse {
+			border: 1px #ddd solid !important;
+			margin-bottom: 4px !important;
+		}
+
+        .mw-100 img {
+        	max-width: 100% !important;
+        }
+        .mw-80 img {
+        	max-width: 80% !important;
+        }
+		.bg-primary {
+		    color: #fff !important;
+		    background-color: #337ab7 !important;
+		}
+		.sub-head {
+		    color: #039 !important;
+			font-size: 14px !important;
+		}
+		.wh-sp-nw {
+			white-space: nowrap;
+		}
+
+	</style>
+
+</head>
+<div id="scroll-top">
+	<a href="javascript:void(0)" class="smooth-scroll">
+		<i class="fa fa-arrow-up fa-2x"></i>
+	</a>
+</div><body>
+	<div class="containbox">
+		<div class="col-md-12 col-xs-12 col-sm-12">
+			<div class="_row">
+				<style type="text/css" media="print">
+
+.Header{
+        display: none;
+    }
+
+</style>
+<header class="Header">
+	<div class="HeaderTop">
+		<a href="https://bangla.dsebd.org/index.php" class="_a_link"> 
+			<img src="assets/images/bangla-songskoron-red.jpg">
+		</a>
+
+		<span class="time">Wednesday, June 17, 2026</span>
+		<span class="time">Current Time: 6:37:41 PM (BST)  </span>
+		<span class="time">Market Status: <span class="green"><b>Closed</b></span></span>
+	</div>
+
+	<div class="HeaderTopMobile col-md-12 col-sm-12 col-xs-18">
+		<span class="time col-md-4 col-sm-3 col-xs-6 pull-left "><a href="http://bangla.dsebd.org/index.php" class="_a_link"><img src="assets/images/bangla-songskoron-red.jpg" class="bngl"></a></span>
+		<span class="time col-md-4 col-sm-3 col-xs-6 pull-left ">Wed, 17 Jun, 26</span>
+		<span class="time col-md-4 col-sm-3 col-xs-6">6:37:41 PM </span>
+		<span class="time col-md-4 col-sm-3 col-xs-6 pull-right"><span class="green"><b>Closed</b></span></span>
+
+	</div>
+
+	<div class="HeaderBottom">
+		<div class="dsktp">
+			<a href="index.php"><img src="assets/images/plc-logo.png" class="logo png_img img-responsive" /></a>
+			<img src="assets/images/dse-name-plc.jpg" class="dsename png_img img-responsive" />
+			<!--img class="mUjib" src="assets/images/mujib10years.png" style="float: right;"-->
+		</div>
+
+		<div class="mobileph">
+			<a href="index.php"><img src="assets/images/plc-logo.png" class="logo png_img img-responsive" /></a>
+			<img src="assets/images/dse-name-p-plc.png" class="dsename png_img img-responsive" />
+			<!--img src="assets/images/mujib10years.png" class="img-responsive mUjibMobile" style="float: right;padding-bottom: 10px; width: 60%;"-->
+		</div>
+
+		<div class="Scroller">
+    		<div class="scroll-item">
+	        				  		<marquee id='mq2'  width='100%' height = '33' align='top' behavior = 'scroll' direction = 'left' onMouseOut=this.start(); onMouseOver=this.stop(); scrollamount='1' scrolldelay='10' truespeed bgcolor='#fffff4'>
+	        	          		<table border="0" cellpadding="0" cellspacing="0" width="100%" >
+					<tr>
+	          								<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=1JANATAMF" class='abhead' target='_top'>
+											1JANATAMF&nbsp;3.00&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=1STPRIMFMF" class='abhead' target='_top'>
+											1STPRIMFMF&nbsp;20.30&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.30&nbsp;&nbsp;&nbsp;&nbsp;-1.46%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=AAMRANET" class='abhead' target='_top'>
+											AAMRANET&nbsp;19.00&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.60&nbsp;&nbsp;&nbsp;&nbsp;3.26%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=AAMRATECH" class='abhead' target='_top'>
+											AAMRATECH&nbsp;14.90&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.68%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ABB1STMF" class='abhead' target='_top'>
+											ABB1STMF&nbsp;3.20&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="105" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ABBANK" class='abhead' target='_top'>
+											ABBANK&nbsp;4.90&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-2.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="100" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ACFL" class='abhead' target='_top'>
+											ACFL&nbsp;&nbsp;&nbsp;24.30&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;0.83%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="100" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ACI" class='abhead' target='_top'>
+											ACI&nbsp;&nbsp;&nbsp;189.40&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.00&nbsp;&nbsp;&nbsp;&nbsp;-0.53%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="135" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ACIFORMULA" class='abhead' target='_top'>
+											ACIFORMULA&nbsp;142.80&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ACMELAB" class='abhead' target='_top'>
+											ACMELAB&nbsp;80.10&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.60&nbsp;&nbsp;&nbsp;&nbsp;0.75%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="110" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ACMEPL" class='abhead' target='_top'>
+											ACMEPL&nbsp;24.40&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.40&nbsp;&nbsp;&nbsp;&nbsp;1.67%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ACTIVEFINE" class='abhead' target='_top'>
+											ACTIVEFINE&nbsp;7.40&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.30&nbsp;&nbsp;&nbsp;&nbsp;4.23%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="110" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ADNTEL" class='abhead' target='_top'>
+											ADNTEL&nbsp;68.70&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				1.50&nbsp;&nbsp;&nbsp;&nbsp;2.23%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="110" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ADVENT" class='abhead' target='_top'>
+											ADVENT&nbsp;15.50&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.40&nbsp;&nbsp;&nbsp;&nbsp;2.65%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="110" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=AFCAGRO" class='abhead' target='_top'>
+											AFCAGRO&nbsp;7.90&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;1.28%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=AFTABAUTO" class='abhead' target='_top'>
+											AFTABAUTO&nbsp;31.80&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.30&nbsp;&nbsp;&nbsp;&nbsp;0.95%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=AGNISYSL" class='abhead' target='_top'>
+											AGNISYSL&nbsp;30.10&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				1.20&nbsp;&nbsp;&nbsp;&nbsp;4.15%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=AGRANINS" class='abhead' target='_top'>
+											AGRANINS&nbsp;26.70&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.20&nbsp;&nbsp;&nbsp;&nbsp;-0.74%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=AIBL1STIMF" class='abhead' target='_top'>
+											AIBL1STIMF&nbsp;4.20&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="135" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=AIBLPBOND" class='abhead' target='_top'>
+											AIBLPBOND&nbsp;3842.00&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-200.50&nbsp;&nbsp;&nbsp;&nbsp;-4.96%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="95" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=AIL" class='abhead' target='_top'>
+											AIL&nbsp;&nbsp;&nbsp;34.30&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;0.59%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=AL-HAJTEX" class='abhead' target='_top'>
+											AL-HAJTEX&nbsp;107.10&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.50&nbsp;&nbsp;&nbsp;&nbsp;-1.38%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ALARABANK" class='abhead' target='_top'>
+											ALARABANK&nbsp;14.50&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="95" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ALIF" class='abhead' target='_top'>
+											ALIF&nbsp;&nbsp;&nbsp;5.50&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="110" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ALLTEX" class='abhead' target='_top'>
+											ALLTEX&nbsp;17.10&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.50&nbsp;&nbsp;&nbsp;&nbsp;3.01%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=AMANFEED" class='abhead' target='_top'>
+											AMANFEED&nbsp;35.10&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.60&nbsp;&nbsp;&nbsp;&nbsp;1.74%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=AMBEEPHA" class='abhead' target='_top'>
+											AMBEEPHA&nbsp;762.00&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.00&nbsp;&nbsp;&nbsp;&nbsp;-0.13%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="135" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=AMCL(PRAN)" class='abhead' target='_top'>
+											AMCL(PRAN)&nbsp;216.90&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.40&nbsp;&nbsp;&nbsp;&nbsp;-0.64%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ANLIMAYARN" class='abhead' target='_top'>
+											ANLIMAYARN&nbsp;34.30&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.50&nbsp;&nbsp;&nbsp;&nbsp;1.48%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ANWARGALV" class='abhead' target='_top'>
+											ANWARGALV&nbsp;116.70&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.09%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="95" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=AOL" class='abhead' target='_top'>
+											AOL&nbsp;&nbsp;&nbsp;18.00&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.60&nbsp;&nbsp;&nbsp;&nbsp;3.45%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=APEXFOODS" class='abhead' target='_top'>
+											APEXFOODS&nbsp;267.90&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.90&nbsp;&nbsp;&nbsp;&nbsp;-0.70%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=APEXFOOT" class='abhead' target='_top'>
+											APEXFOOT&nbsp;200.90&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.50&nbsp;&nbsp;&nbsp;&nbsp;0.25%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=APEXSPINN" class='abhead' target='_top'>
+											APEXSPINN&nbsp;332.40&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-22.00&nbsp;&nbsp;&nbsp;&nbsp;-6.21%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=APEXTANRY" class='abhead' target='_top'>
+											APEXTANRY&nbsp;100.70&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-2.20&nbsp;&nbsp;&nbsp;&nbsp;-2.14%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=APOLOISPAT" class='abhead' target='_top'>
+											APOLOISPAT&nbsp;3.50&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;6.06%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="135" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=APSCLBOND" class='abhead' target='_top'>
+											APSCLBOND&nbsp;1121.00&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-69.00&nbsp;&nbsp;&nbsp;&nbsp;-5.80%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ARAMIT" class='abhead' target='_top'>
+											ARAMIT&nbsp;191.00&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				2.10&nbsp;&nbsp;&nbsp;&nbsp;1.11%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ARAMITCEM" class='abhead' target='_top'>
+											ARAMITCEM&nbsp;12.60&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.80%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ARGONDENIM" class='abhead' target='_top'>
+											ARGONDENIM&nbsp;19.70&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ASIAINS" class='abhead' target='_top'>
+											ASIAINS&nbsp;42.00&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.30&nbsp;&nbsp;&nbsp;&nbsp;-3.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ASIAPACINS" class='abhead' target='_top'>
+											ASIAPACINS&nbsp;45.30&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.60&nbsp;&nbsp;&nbsp;&nbsp;-1.31%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="135" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ASIATICLAB" class='abhead' target='_top'>
+											ASIATICLAB&nbsp;123.50&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				2.80&nbsp;&nbsp;&nbsp;&nbsp;2.32%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ATLASBANG" class='abhead' target='_top'>
+											ATLASBANG&nbsp;69.00&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.30&nbsp;&nbsp;&nbsp;&nbsp;-0.43%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=AZIZPIPES" class='abhead' target='_top'>
+											AZIZPIPES&nbsp;78.70&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.70&nbsp;&nbsp;&nbsp;&nbsp;0.90%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BANGAS" class='abhead' target='_top'>
+											BANGAS&nbsp;134.10&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.70&nbsp;&nbsp;&nbsp;&nbsp;-0.52%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BANKASIA" class='abhead' target='_top'>
+											BANKASIA&nbsp;18.40&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-0.54%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BARKAPOWER" class='abhead' target='_top'>
+											BARKAPOWER&nbsp;8.70&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;2.35%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BATASHOE" class='abhead' target='_top'>
+											BATASHOE&nbsp;874.80&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				16.70&nbsp;&nbsp;&nbsp;&nbsp;1.95%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="110" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BATBC" class='abhead' target='_top'>
+											BATBC&nbsp;&nbsp;&nbsp;212.20&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.05%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BAYLEASING" class='abhead' target='_top'>
+											BAYLEASING&nbsp;4.70&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="95" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BBS" class='abhead' target='_top'>
+											BBS&nbsp;&nbsp;&nbsp;16.10&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				1.30&nbsp;&nbsp;&nbsp;&nbsp;8.78%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BBSCABLES" class='abhead' target='_top'>
+											BBSCABLES&nbsp;24.80&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.80&nbsp;&nbsp;&nbsp;&nbsp;3.33%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BDAUTOCA" class='abhead' target='_top'>
+											BDAUTOCA&nbsp;216.30&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-2.40&nbsp;&nbsp;&nbsp;&nbsp;-1.10%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="105" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BDCOM" class='abhead' target='_top'>
+											BDCOM&nbsp;&nbsp;&nbsp;33.00&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				2.90&nbsp;&nbsp;&nbsp;&nbsp;9.63%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BDFINANCE" class='abhead' target='_top'>
+											BDFINANCE&nbsp;13.50&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.75%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BDLAMPS" class='abhead' target='_top'>
+											BDLAMPS&nbsp;175.20&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.90&nbsp;&nbsp;&nbsp;&nbsp;-1.07%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="110" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BDTHAI" class='abhead' target='_top'>
+											BDTHAI&nbsp;20.30&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-0.49%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BDTHAIFOOD" class='abhead' target='_top'>
+											BDTHAIFOOD&nbsp;29.20&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.70&nbsp;&nbsp;&nbsp;&nbsp;-5.50%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BDWELDING" class='abhead' target='_top'>
+											BDWELDING&nbsp;15.80&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-0.63%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BEACHHATCH" class='abhead' target='_top'>
+											BEACHHATCH&nbsp;34.00&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				1.10&nbsp;&nbsp;&nbsp;&nbsp;3.34%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="135" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BEACONPHAR" class='abhead' target='_top'>
+											BEACONPHAR&nbsp;108.50&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.20&nbsp;&nbsp;&nbsp;&nbsp;-0.18%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BENGALWTL" class='abhead' target='_top'>
+											BENGALWTL&nbsp;25.20&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.40&nbsp;&nbsp;&nbsp;&nbsp;1.61%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="135" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BERGERPBL" class='abhead' target='_top'>
+											BERGERPBL&nbsp;1418.00&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				2.60&nbsp;&nbsp;&nbsp;&nbsp;0.18%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BESTHLDNG" class='abhead' target='_top'>
+											BESTHLDNG&nbsp;14.80&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-0.67%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BEXGSUKUK" class='abhead' target='_top'>
+											BEXGSUKUK&nbsp;72.50&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.50&nbsp;&nbsp;&nbsp;&nbsp;0.69%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BEXIMCO" class='abhead' target='_top'>
+											BEXIMCO&nbsp;52.80&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-5.80&nbsp;&nbsp;&nbsp;&nbsp;-9.90%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="100" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BGIC" class='abhead' target='_top'>
+											BGIC&nbsp;&nbsp;&nbsp;39.80&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.50&nbsp;&nbsp;&nbsp;&nbsp;-1.24%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="95" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BIFC" class='abhead' target='_top'>
+											BIFC&nbsp;&nbsp;&nbsp;4.40&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-2.22%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="110" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BNICL" class='abhead' target='_top'>
+											BNICL&nbsp;&nbsp;&nbsp;103.90&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-4.40&nbsp;&nbsp;&nbsp;&nbsp;-4.06%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="100" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BPML" class='abhead' target='_top'>
+											BPML&nbsp;&nbsp;&nbsp;28.60&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.20&nbsp;&nbsp;&nbsp;&nbsp;-0.69%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="100" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BPPL" class='abhead' target='_top'>
+											BPPL&nbsp;&nbsp;&nbsp;20.60&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.49%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BRACBANK" class='abhead' target='_top'>
+											BRACBANK&nbsp;65.60&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.50&nbsp;&nbsp;&nbsp;&nbsp;-0.76%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="100" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BSC" class='abhead' target='_top'>
+											BSC&nbsp;&nbsp;&nbsp;107.30&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.70&nbsp;&nbsp;&nbsp;&nbsp;-0.65%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BSCPLC" class='abhead' target='_top'>
+											BSCPLC&nbsp;147.30&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;0.14%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BSRMLTD" class='abhead' target='_top'>
+											BSRMLTD&nbsp;92.90&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.11%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BSRMSTEEL" class='abhead' target='_top'>
+											BSRMSTEEL&nbsp;79.00&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.90&nbsp;&nbsp;&nbsp;&nbsp;1.15%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=BXPHARMA" class='abhead' target='_top'>
+											BXPHARMA&nbsp;134.70&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				2.40&nbsp;&nbsp;&nbsp;&nbsp;1.81%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=CAPITECGBF" class='abhead' target='_top'>
+											CAPITECGBF&nbsp;7.50&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=CAPMBDBLMF" class='abhead' target='_top'>
+											CAPMBDBLMF&nbsp;9.90&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=CAPMIBBLMF" class='abhead' target='_top'>
+											CAPMIBBLMF&nbsp;9.60&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;1.05%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=CENTRALINS" class='abhead' target='_top'>
+											CENTRALINS&nbsp;43.10&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.70&nbsp;&nbsp;&nbsp;&nbsp;-1.60%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=CENTRALPHL" class='abhead' target='_top'>
+											CENTRALPHL&nbsp;9.60&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.30&nbsp;&nbsp;&nbsp;&nbsp;3.23%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=CITYBANK" class='abhead' target='_top'>
+											CITYBANK&nbsp;30.50&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="135" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=CITYGENINS" class='abhead' target='_top'>
+											CITYGENINS&nbsp;106.80&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.40&nbsp;&nbsp;&nbsp;&nbsp;0.38%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="105" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=CLICL" class='abhead' target='_top'>
+											CLICL&nbsp;&nbsp;&nbsp;54.20&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.70&nbsp;&nbsp;&nbsp;&nbsp;-3.04%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="105" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=CNATEX" class='abhead' target='_top'>
+											CNATEX&nbsp;3.40&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;6.25%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=CONFIDCEM" class='abhead' target='_top'>
+											CONFIDCEM&nbsp;63.80&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.40&nbsp;&nbsp;&nbsp;&nbsp;-0.62%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=CONTININS" class='abhead' target='_top'>
+											CONTININS&nbsp;33.00&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=COPPERTECH" class='abhead' target='_top'>
+											COPPERTECH&nbsp;28.20&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.80&nbsp;&nbsp;&nbsp;&nbsp;2.92%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=CROWNCEMNT" class='abhead' target='_top'>
+											CROWNCEMNT&nbsp;55.10&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=CRYSTALINS" class='abhead' target='_top'>
+											CRYSTALINS&nbsp;71.90&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.40&nbsp;&nbsp;&nbsp;&nbsp;-1.91%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=CVOPRL" class='abhead' target='_top'>
+											CVOPRL&nbsp;166.30&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-0.06%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=DACCADYE" class='abhead' target='_top'>
+											DACCADYE&nbsp;17.50&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="135" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=DAFODILCOM" class='abhead' target='_top'>
+											DAFODILCOM&nbsp;159.80&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				2.20&nbsp;&nbsp;&nbsp;&nbsp;1.40%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="95" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=DBH" class='abhead' target='_top'>
+											DBH&nbsp;&nbsp;&nbsp;41.00&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.30&nbsp;&nbsp;&nbsp;&nbsp;-0.73%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=DBH1STMF" class='abhead' target='_top'>
+											DBH1STMF&nbsp;4.70&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=DELTALIFE" class='abhead' target='_top'>
+											DELTALIFE&nbsp;80.60&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.40&nbsp;&nbsp;&nbsp;&nbsp;-1.71%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=DELTASPINN" class='abhead' target='_top'>
+											DELTASPINN&nbsp;6.90&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;1.47%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="105" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=DESCO" class='abhead' target='_top'>
+											DESCO&nbsp;&nbsp;&nbsp;23.90&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.40&nbsp;&nbsp;&nbsp;&nbsp;-1.65%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=DESHBANDHU" class='abhead' target='_top'>
+											DESHBANDHU&nbsp;21.70&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.46%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="100" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=DGIC" class='abhead' target='_top'>
+											DGIC&nbsp;&nbsp;&nbsp;29.10&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.40&nbsp;&nbsp;&nbsp;&nbsp;-1.36%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=DHAKABANK" class='abhead' target='_top'>
+											DHAKABANK&nbsp;12.00&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=DOMINAGE" class='abhead' target='_top'>
+											DOMINAGE&nbsp;79.90&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-0.12%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=DOREENPWR" class='abhead' target='_top'>
+											DOREENPWR&nbsp;31.80&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.60&nbsp;&nbsp;&nbsp;&nbsp;-1.85%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=DSHGARME" class='abhead' target='_top'>
+											DSHGARME&nbsp;143.00&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-3.90&nbsp;&nbsp;&nbsp;&nbsp;-2.65%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="100" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=DSSL" class='abhead' target='_top'>
+											DSSL&nbsp;&nbsp;&nbsp;11.10&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-0.89%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="135" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=DULAMIACOT" class='abhead' target='_top'>
+											DULAMIACOT&nbsp;181.90&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.60&nbsp;&nbsp;&nbsp;&nbsp;-0.87%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=DUTCHBANGL" class='abhead' target='_top'>
+											DUTCHBANGL&nbsp;43.10&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;0.47%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=EASTERNINS" class='abhead' target='_top'>
+											EASTERNINS&nbsp;59.10&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-2.60&nbsp;&nbsp;&nbsp;&nbsp;-4.21%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=EASTLAND" class='abhead' target='_top'>
+											EASTLAND&nbsp;26.00&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-0.38%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="135" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=EASTRNLUB" class='abhead' target='_top'>
+											EASTRNLUB&nbsp;1832.70&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.20&nbsp;&nbsp;&nbsp;&nbsp;-0.07%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="95" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=EBL" class='abhead' target='_top'>
+											EBL&nbsp;&nbsp;&nbsp;24.80&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=EBL1STMF" class='abhead' target='_top'>
+											EBL1STMF&nbsp;3.80&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=EBLNRBMF" class='abhead' target='_top'>
+											EBLNRBMF&nbsp;3.10&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ECABLES" class='abhead' target='_top'>
+											ECABLES&nbsp;124.70&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				2.00&nbsp;&nbsp;&nbsp;&nbsp;1.63%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="100" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=EGEN" class='abhead' target='_top'>
+											EGEN&nbsp;&nbsp;&nbsp;26.90&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				1.00&nbsp;&nbsp;&nbsp;&nbsp;3.86%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="95" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=EHL" class='abhead' target='_top'>
+											EHL&nbsp;&nbsp;&nbsp;88.10&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.20&nbsp;&nbsp;&nbsp;&nbsp;-0.23%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="95" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=EIL" class='abhead' target='_top'>
+											EIL&nbsp;&nbsp;&nbsp;30.30&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.40&nbsp;&nbsp;&nbsp;&nbsp;-1.30%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=EMERALDOIL" class='abhead' target='_top'>
+											EMERALDOIL&nbsp;23.20&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.50&nbsp;&nbsp;&nbsp;&nbsp;-2.11%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ENVOYTEX" class='abhead' target='_top'>
+											ENVOYTEX&nbsp;52.10&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.19%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="100" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=EPGL" class='abhead' target='_top'>
+											EPGL&nbsp;&nbsp;&nbsp;20.60&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ESQUIRENIT" class='abhead' target='_top'>
+											ESQUIRENIT&nbsp;24.80&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.40%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="95" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ETL" class='abhead' target='_top'>
+											ETL&nbsp;&nbsp;&nbsp;13.30&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.20&nbsp;&nbsp;&nbsp;&nbsp;-1.48%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=EXIM1STMF" class='abhead' target='_top'>
+											EXIM1STMF&nbsp;3.50&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=FAMILYTEX" class='abhead' target='_top'>
+											FAMILYTEX&nbsp;2.80&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=FARCHEM" class='abhead' target='_top'>
+											FARCHEM&nbsp;19.20&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;1.05%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=FAREASTFIN" class='abhead' target='_top'>
+											FAREASTFIN&nbsp;1.30&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-7.14%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=FAREASTLIF" class='abhead' target='_top'>
+											FAREASTLIF&nbsp;24.20&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;0.83%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="105" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=FASFIN" class='abhead' target='_top'>
+											FASFIN&nbsp;1.30&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-7.14%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="100" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=FBFIF" class='abhead' target='_top'>
+											FBFIF&nbsp;&nbsp;&nbsp;3.10&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=FEDERALINS" class='abhead' target='_top'>
+											FEDERALINS&nbsp;28.00&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.70&nbsp;&nbsp;&nbsp;&nbsp;-5.72%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="110" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=FEKDIL" class='abhead' target='_top'>
+											FEKDIL&nbsp;17.10&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.20&nbsp;&nbsp;&nbsp;&nbsp;-1.16%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=FINEFOODS" class='abhead' target='_top'>
+											FINEFOODS&nbsp;543.60&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.00&nbsp;&nbsp;&nbsp;&nbsp;-0.18%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=FIRSTFIN" class='abhead' target='_top'>
+											FIRSTFIN&nbsp;4.30&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=FORTUNE" class='abhead' target='_top'>
+											FORTUNE&nbsp;15.90&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;1.27%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=FUWANGCER" class='abhead' target='_top'>
+											FUWANGCER&nbsp;15.90&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.40&nbsp;&nbsp;&nbsp;&nbsp;2.58%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=FUWANGFOOD" class='abhead' target='_top'>
+											FUWANGFOOD&nbsp;11.50&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.50&nbsp;&nbsp;&nbsp;&nbsp;4.55%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=GBBPOWER" class='abhead' target='_top'>
+											GBBPOWER&nbsp;8.80&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=GEMINISEA" class='abhead' target='_top'>
+											GEMINISEA&nbsp;117.00&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.50&nbsp;&nbsp;&nbsp;&nbsp;-0.43%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=GENEXIL" class='abhead' target='_top'>
+											GENEXIL&nbsp;37.20&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				1.80&nbsp;&nbsp;&nbsp;&nbsp;5.08%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="110" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=GENNEXT" class='abhead' target='_top'>
+											GENNEXT&nbsp;3.30&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;6.45%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="105" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=GHAIL" class='abhead' target='_top'>
+											GHAIL&nbsp;&nbsp;&nbsp;15.60&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.60&nbsp;&nbsp;&nbsp;&nbsp;4.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="100" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=GHCL" class='abhead' target='_top'>
+											GHCL&nbsp;&nbsp;&nbsp;20.80&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;0.97%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="110" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=GLDNJMF" class='abhead' target='_top'>
+											GLDNJMF&nbsp;6.50&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-1.52%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=GLOBALINS" class='abhead' target='_top'>
+											GLOBALINS&nbsp;37.60&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.50&nbsp;&nbsp;&nbsp;&nbsp;-1.31%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=GOLDENSON" class='abhead' target='_top'>
+											GOLDENSON&nbsp;17.20&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.50&nbsp;&nbsp;&nbsp;&nbsp;2.99%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="95" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=GP" class='abhead' target='_top'>
+											GP&nbsp;&nbsp;&nbsp;251.50&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.90&nbsp;&nbsp;&nbsp;&nbsp;0.36%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=GPHISPAT" class='abhead' target='_top'>
+											GPHISPAT&nbsp;18.00&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;1.12%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=GQBALLPEN" class='abhead' target='_top'>
+											GQBALLPEN&nbsp;634.50&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-6.60&nbsp;&nbsp;&nbsp;&nbsp;-1.03%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=GRAMEENS2" class='abhead' target='_top'>
+											GRAMEENS2&nbsp;12.80&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.30&nbsp;&nbsp;&nbsp;&nbsp;2.40%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=GREENDELMF" class='abhead' target='_top'>
+											GREENDELMF&nbsp;3.50&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;2.94%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=GREENDELT" class='abhead' target='_top'>
+											GREENDELT&nbsp;66.50&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.10&nbsp;&nbsp;&nbsp;&nbsp;-1.63%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=GSPFINANCE" class='abhead' target='_top'>
+											GSPFINANCE&nbsp;3.70&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-2.63%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=HAKKANIPUL" class='abhead' target='_top'>
+											HAKKANIPUL&nbsp;79.20&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.40&nbsp;&nbsp;&nbsp;&nbsp;0.51%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="105" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=HAMI" class='abhead' target='_top'>
+											HAMI&nbsp;&nbsp;&nbsp;156.60&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-4.50&nbsp;&nbsp;&nbsp;&nbsp;-2.79%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="135" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=HEIDELBCEM" class='abhead' target='_top'>
+											HEIDELBCEM&nbsp;227.40&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-2.80&nbsp;&nbsp;&nbsp;&nbsp;-1.22%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="95" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=HFL" class='abhead' target='_top'>
+											HFL&nbsp;&nbsp;&nbsp;16.00&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				1.40&nbsp;&nbsp;&nbsp;&nbsp;9.59%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="105" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=HRTEX" class='abhead' target='_top'>
+											HRTEX&nbsp;&nbsp;&nbsp;21.40&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.30&nbsp;&nbsp;&nbsp;&nbsp;1.42%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=HWAWELLTEX" class='abhead' target='_top'>
+											HWAWELLTEX&nbsp;45.10&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.30&nbsp;&nbsp;&nbsp;&nbsp;0.67%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=IBBLPBOND" class='abhead' target='_top'>
+											IBBLPBOND&nbsp;675.00&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				12.00&nbsp;&nbsp;&nbsp;&nbsp;1.81%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=IBNSINA" class='abhead' target='_top'>
+											IBNSINA&nbsp;314.00&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.03%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="95" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=IBP" class='abhead' target='_top'>
+											IBP&nbsp;&nbsp;&nbsp;16.00&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.50&nbsp;&nbsp;&nbsp;&nbsp;3.23%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="95" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ICB" class='abhead' target='_top'>
+											ICB&nbsp;&nbsp;&nbsp;44.00&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.60&nbsp;&nbsp;&nbsp;&nbsp;1.38%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ICB3RDNRB" class='abhead' target='_top'>
+											ICB3RDNRB&nbsp;4.60&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-2.13%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ICBAGRANI1" class='abhead' target='_top'>
+											ICBAGRANI1&nbsp;6.80&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ICBAMCL2ND" class='abhead' target='_top'>
+											ICBAMCL2ND&nbsp;6.30&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;1.61%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ICBEPMF1S1" class='abhead' target='_top'>
+											ICBEPMF1S1&nbsp;6.30&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.30&nbsp;&nbsp;&nbsp;&nbsp;-4.55%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ICBIBANK" class='abhead' target='_top'>
+											ICBIBANK&nbsp;2.90&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ICBSONALI1" class='abhead' target='_top'>
+											ICBSONALI1&nbsp;5.00&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="105" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ICICL" class='abhead' target='_top'>
+											ICICL&nbsp;&nbsp;&nbsp;29.20&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-0.34%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="100" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=IDLC" class='abhead' target='_top'>
+											IDLC&nbsp;&nbsp;&nbsp;40.80&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.30&nbsp;&nbsp;&nbsp;&nbsp;-0.73%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=IFADAUTOS" class='abhead' target='_top'>
+											IFADAUTOS&nbsp;24.70&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.30&nbsp;&nbsp;&nbsp;&nbsp;1.23%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="95" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=IFIC" class='abhead' target='_top'>
+											IFIC&nbsp;&nbsp;&nbsp;5.00&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=IFIC1STMF" class='abhead' target='_top'>
+											IFIC1STMF&nbsp;3.50&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=IFILISLMF1" class='abhead' target='_top'>
+											IFILISLMF1&nbsp;4.10&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-2.38%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="100" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ILFSL" class='abhead' target='_top'>
+											ILFSL&nbsp;&nbsp;&nbsp;1.30&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-7.14%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=INDEXAGRO" class='abhead' target='_top'>
+											INDEXAGRO&nbsp;72.00&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-0.14%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="110" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=INTECH" class='abhead' target='_top'>
+											INTECH&nbsp;36.50&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				1.20&nbsp;&nbsp;&nbsp;&nbsp;3.40%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=INTRACO" class='abhead' target='_top'>
+											INTRACO&nbsp;20.40&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;0.99%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="100" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=IPDC" class='abhead' target='_top'>
+											IPDC&nbsp;&nbsp;&nbsp;28.80&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.50&nbsp;&nbsp;&nbsp;&nbsp;1.77%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ISLAMIBANK" class='abhead' target='_top'>
+											ISLAMIBANK&nbsp;33.80&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.30&nbsp;&nbsp;&nbsp;&nbsp;-0.88%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ISLAMICFIN" class='abhead' target='_top'>
+											ISLAMICFIN&nbsp;11.10&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.91%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ISLAMIINS" class='abhead' target='_top'>
+											ISLAMIINS&nbsp;58.80&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				3.80&nbsp;&nbsp;&nbsp;&nbsp;6.91%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="110" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ISNLTD" class='abhead' target='_top'>
+											ISNLTD&nbsp;63.20&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				2.30&nbsp;&nbsp;&nbsp;&nbsp;3.78%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="95" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ITC" class='abhead' target='_top'>
+											ITC&nbsp;&nbsp;&nbsp;42.70&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				1.40&nbsp;&nbsp;&nbsp;&nbsp;3.39%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=JAMUNABANK" class='abhead' target='_top'>
+											JAMUNABANK&nbsp;23.90&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.42%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=JAMUNAOIL" class='abhead' target='_top'>
+											JAMUNAOIL&nbsp;176.50&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.80&nbsp;&nbsp;&nbsp;&nbsp;0.46%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=JANATAINS" class='abhead' target='_top'>
+											JANATAINS&nbsp;35.10&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.30&nbsp;&nbsp;&nbsp;&nbsp;-0.85%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="105" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=JHRML" class='abhead' target='_top'>
+											JHRML&nbsp;&nbsp;&nbsp;50.50&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.20%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=JMISMDL" class='abhead' target='_top'>
+											JMISMDL&nbsp;128.10&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				1.10&nbsp;&nbsp;&nbsp;&nbsp;0.87%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=JUTESPINN" class='abhead' target='_top'>
+											JUTESPINN&nbsp;208.20&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.30&nbsp;&nbsp;&nbsp;&nbsp;-0.14%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=KARNAPHULI" class='abhead' target='_top'>
+											KARNAPHULI&nbsp;37.20&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.60&nbsp;&nbsp;&nbsp;&nbsp;-1.59%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=KAY&QUE" class='abhead' target='_top'>
+											KAY&QUE&nbsp;431.70&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-6.80&nbsp;&nbsp;&nbsp;&nbsp;-1.55%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=KBPPWBIL" class='abhead' target='_top'>
+											KBPPWBIL&nbsp;47.30&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.60&nbsp;&nbsp;&nbsp;&nbsp;1.28%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=KDSALTD" class='abhead' target='_top'>
+											KDSALTD&nbsp;48.70&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.30&nbsp;&nbsp;&nbsp;&nbsp;-0.61%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=KEYACOSMET" class='abhead' target='_top'>
+											KEYACOSMET&nbsp;5.00&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;4.17%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=KOHINOOR" class='abhead' target='_top'>
+											KOHINOOR&nbsp;502.20&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-5.80&nbsp;&nbsp;&nbsp;&nbsp;-1.14%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="100" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=KPCL" class='abhead' target='_top'>
+											KPCL&nbsp;&nbsp;&nbsp;11.00&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.92%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="100" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=KPPL" class='abhead' target='_top'>
+											KPPL&nbsp;&nbsp;&nbsp;15.80&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="95" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=KTL" class='abhead' target='_top'>
+											KTL&nbsp;&nbsp;&nbsp;10.60&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;1.92%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=LANKABAFIN" class='abhead' target='_top'>
+											LANKABAFIN&nbsp;16.50&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.20&nbsp;&nbsp;&nbsp;&nbsp;-1.20%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=LEGACYFOOT" class='abhead' target='_top'>
+											LEGACYFOOT&nbsp;67.80&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.50&nbsp;&nbsp;&nbsp;&nbsp;-0.73%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="95" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=LHB" class='abhead' target='_top'>
+											LHB&nbsp;&nbsp;&nbsp;54.40&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.18%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=LIBRAINFU" class='abhead' target='_top'>
+											LIBRAINFU&nbsp;639.80&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-6.50&nbsp;&nbsp;&nbsp;&nbsp;-1.01%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=LINDEBD" class='abhead' target='_top'>
+											LINDEBD&nbsp;699.10&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				2.00&nbsp;&nbsp;&nbsp;&nbsp;0.29%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=LOVELLO" class='abhead' target='_top'>
+											LOVELLO&nbsp;71.20&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.14%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="105" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=LRBDL" class='abhead' target='_top'>
+											LRBDL&nbsp;&nbsp;&nbsp;11.90&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;1.71%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=LRGLOBMF1" class='abhead' target='_top'>
+											LRGLOBMF1&nbsp;3.40&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;6.25%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MAGURAPLEX" class='abhead' target='_top'>
+											MAGURAPLEX&nbsp;87.40&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;0.23%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MAKSONSPIN" class='abhead' target='_top'>
+											MAKSONSPIN&nbsp;6.10&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;1.67%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MALEKSPIN" class='abhead' target='_top'>
+											MALEKSPIN&nbsp;31.10&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.60&nbsp;&nbsp;&nbsp;&nbsp;1.97%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MARICO" class='abhead' target='_top'>
+											MARICO&nbsp;2748.20&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				3.30&nbsp;&nbsp;&nbsp;&nbsp;0.12%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MATINSPINN" class='abhead' target='_top'>
+											MATINSPINN&nbsp;52.10&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.50&nbsp;&nbsp;&nbsp;&nbsp;0.97%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MBL1STMF" class='abhead' target='_top'>
+											MBL1STMF&nbsp;3.90&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MEGCONMILK" class='abhead' target='_top'>
+											MEGCONMILK&nbsp;40.30&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				2.10&nbsp;&nbsp;&nbsp;&nbsp;5.50%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MEGHNACEM" class='abhead' target='_top'>
+											MEGHNACEM&nbsp;32.00&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-0.31%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MEGHNAINS" class='abhead' target='_top'>
+											MEGHNAINS&nbsp;34.40&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.60&nbsp;&nbsp;&nbsp;&nbsp;-1.71%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MEGHNALIFE" class='abhead' target='_top'>
+											MEGHNALIFE&nbsp;60.50&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.70&nbsp;&nbsp;&nbsp;&nbsp;-1.14%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MEGHNAPET" class='abhead' target='_top'>
+											MEGHNAPET&nbsp;77.80&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;0.26%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MERCANBANK" class='abhead' target='_top'>
+											MERCANBANK&nbsp;7.50&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;2.74%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MERCINS" class='abhead' target='_top'>
+											MERCINS&nbsp;39.00&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.80&nbsp;&nbsp;&nbsp;&nbsp;2.09%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=METROSPIN" class='abhead' target='_top'>
+											METROSPIN&nbsp;9.60&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;1.05%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="105" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MHSML" class='abhead' target='_top'>
+											MHSML&nbsp;&nbsp;&nbsp;23.30&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				1.00&nbsp;&nbsp;&nbsp;&nbsp;4.48%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MIDASFIN" class='abhead' target='_top'>
+											MIDASFIN&nbsp;6.20&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.50&nbsp;&nbsp;&nbsp;&nbsp;8.77%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MIDLANDBNK" class='abhead' target='_top'>
+											MIDLANDBNK&nbsp;16.50&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;1.23%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MIRACLEIND" class='abhead' target='_top'>
+											MIRACLEIND&nbsp;28.10&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.36%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MIRAKHTER" class='abhead' target='_top'>
+											MIRAKHTER&nbsp;41.80&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.50&nbsp;&nbsp;&nbsp;&nbsp;1.21%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MITHUNKNIT" class='abhead' target='_top'>
+											MITHUNKNIT&nbsp;15.50&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="105" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MJLBD" class='abhead' target='_top'>
+											MJLBD&nbsp;&nbsp;&nbsp;90.50&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.40&nbsp;&nbsp;&nbsp;&nbsp;-1.52%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MLDYEING" class='abhead' target='_top'>
+											MLDYEING&nbsp;11.40&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.40&nbsp;&nbsp;&nbsp;&nbsp;3.64%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MONNOAGML" class='abhead' target='_top'>
+											MONNOAGML&nbsp;347.00&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-3.90&nbsp;&nbsp;&nbsp;&nbsp;-1.11%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MONNOCERA" class='abhead' target='_top'>
+											MONNOCERA&nbsp;95.90&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;0.21%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MONNOFABR" class='abhead' target='_top'>
+											MONNOFABR&nbsp;23.20&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;0.87%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MONOSPOOL" class='abhead' target='_top'>
+											MONOSPOOL&nbsp;109.30&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				1.00&nbsp;&nbsp;&nbsp;&nbsp;0.92%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="135" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MPETROLEUM" class='abhead' target='_top'>
+											MPETROLEUM&nbsp;209.00&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="95" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=MTB" class='abhead' target='_top'>
+											MTB&nbsp;&nbsp;&nbsp;13.90&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.30&nbsp;&nbsp;&nbsp;&nbsp;2.21%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=NAHEEACP" class='abhead' target='_top'>
+											NAHEEACP&nbsp;35.90&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.60&nbsp;&nbsp;&nbsp;&nbsp;1.70%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="135" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=NATLIFEINS" class='abhead' target='_top'>
+											NATLIFEINS&nbsp;104.10&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.60&nbsp;&nbsp;&nbsp;&nbsp;0.58%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=NAVANACNG" class='abhead' target='_top'>
+											NAVANACNG&nbsp;22.00&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.30&nbsp;&nbsp;&nbsp;&nbsp;1.38%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=NAVANAPHAR" class='abhead' target='_top'>
+											NAVANAPHAR&nbsp;70.90&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.40&nbsp;&nbsp;&nbsp;&nbsp;0.57%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="90" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=NBL" class='abhead' target='_top'>
+											NBL&nbsp;&nbsp;&nbsp;4.10&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=NCCBANK" class='abhead' target='_top'>
+											NCCBANK&nbsp;16.60&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=NCCBLMF1" class='abhead' target='_top'>
+											NCCBLMF1&nbsp;4.30&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;2.38%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="110" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=NEWLINE" class='abhead' target='_top'>
+											NEWLINE&nbsp;6.10&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.50&nbsp;&nbsp;&nbsp;&nbsp;8.93%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="100" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=NFML" class='abhead' target='_top'>
+											NFML&nbsp;&nbsp;&nbsp;20.90&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				1.90&nbsp;&nbsp;&nbsp;&nbsp;10.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="105" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=NHFIL" class='abhead' target='_top'>
+											NHFIL&nbsp;&nbsp;&nbsp;27.60&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-0.36%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=NITOLINS" class='abhead' target='_top'>
+											NITOLINS&nbsp;34.60&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.30&nbsp;&nbsp;&nbsp;&nbsp;-0.86%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=NORTHERN" class='abhead' target='_top'>
+											NORTHERN&nbsp;111.30&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				1.30&nbsp;&nbsp;&nbsp;&nbsp;1.18%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=NORTHRNINS" class='abhead' target='_top'>
+											NORTHRNINS&nbsp;41.30&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.20&nbsp;&nbsp;&nbsp;&nbsp;-0.48%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=NPOLYMER" class='abhead' target='_top'>
+											NPOLYMER&nbsp;33.40&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.30%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=NRBCBANK" class='abhead' target='_top'>
+											NRBCBANK&nbsp;7.40&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=NTLTUBES" class='abhead' target='_top'>
+											NTLTUBES&nbsp;66.00&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.50&nbsp;&nbsp;&nbsp;&nbsp;-0.75%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="105" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=NURANI" class='abhead' target='_top'>
+											NURANI&nbsp;3.20&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;3.23%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="90" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=OAL" class='abhead' target='_top'>
+											OAL&nbsp;&nbsp;&nbsp;6.70&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.40&nbsp;&nbsp;&nbsp;&nbsp;6.35%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="105" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=OIMEX" class='abhead' target='_top'>
+											OIMEX&nbsp;&nbsp;&nbsp;16.10&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.63%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=OLYMPIC" class='abhead' target='_top'>
+											OLYMPIC&nbsp;149.40&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				1.10&nbsp;&nbsp;&nbsp;&nbsp;0.74%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ONEBANKPLC" class='abhead' target='_top'>
+											ONEBANKPLC&nbsp;8.20&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ORIONINFU" class='abhead' target='_top'>
+											ORIONINFU&nbsp;315.20&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.50&nbsp;&nbsp;&nbsp;&nbsp;-0.47%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ORIONPHARM" class='abhead' target='_top'>
+											ORIONPHARM&nbsp;28.90&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-0.34%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PADMALIFE" class='abhead' target='_top'>
+											PADMALIFE&nbsp;19.50&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PADMAOIL" class='abhead' target='_top'>
+											PADMAOIL&nbsp;184.40&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;0.11%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PARAMOUNT" class='abhead' target='_top'>
+											PARAMOUNT&nbsp;60.80&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.60&nbsp;&nbsp;&nbsp;&nbsp;-2.56%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="90" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PDL" class='abhead' target='_top'>
+											PDL&nbsp;&nbsp;&nbsp;6.20&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.50&nbsp;&nbsp;&nbsp;&nbsp;8.77%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PENINSULA" class='abhead' target='_top'>
+											PENINSULA&nbsp;23.20&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.43%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PEOPLESINS" class='abhead' target='_top'>
+											PEOPLESINS&nbsp;58.50&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.60&nbsp;&nbsp;&nbsp;&nbsp;-2.66%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="110" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PF1STMF" class='abhead' target='_top'>
+											PF1STMF&nbsp;8.60&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;2.38%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PHARMAID" class='abhead' target='_top'>
+											PHARMAID&nbsp;567.80&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-3.60&nbsp;&nbsp;&nbsp;&nbsp;-0.63%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PHENIXINS" class='abhead' target='_top'>
+											PHENIXINS&nbsp;42.90&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.40&nbsp;&nbsp;&nbsp;&nbsp;-0.92%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PHOENIXFIN" class='abhead' target='_top'>
+											PHOENIXFIN&nbsp;3.80&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-2.56%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="105" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PHPMF1" class='abhead' target='_top'>
+											PHPMF1&nbsp;3.10&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PIONEERINS" class='abhead' target='_top'>
+											PIONEERINS&nbsp;67.50&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.40&nbsp;&nbsp;&nbsp;&nbsp;-0.59%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="100" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PLFSL" class='abhead' target='_top'>
+											PLFSL&nbsp;&nbsp;&nbsp;1.40&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=POPULAR1MF" class='abhead' target='_top'>
+											POPULAR1MF&nbsp;3.10&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=POPULARLIF" class='abhead' target='_top'>
+											POPULARLIF&nbsp;62.10&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.70&nbsp;&nbsp;&nbsp;&nbsp;-1.11%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=POWERGRID" class='abhead' target='_top'>
+											POWERGRID&nbsp;37.90&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.40&nbsp;&nbsp;&nbsp;&nbsp;-1.04%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PRAGATIINS" class='abhead' target='_top'>
+											PRAGATIINS&nbsp;74.10&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.90&nbsp;&nbsp;&nbsp;&nbsp;-1.20%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="135" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PRAGATILIF" class='abhead' target='_top'>
+											PRAGATILIF&nbsp;184.40&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.40&nbsp;&nbsp;&nbsp;&nbsp;-0.75%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PREMIERBAN" class='abhead' target='_top'>
+											PREMIERBAN&nbsp;4.50&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;2.27%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PREMIERCEM" class='abhead' target='_top'>
+											PREMIERCEM&nbsp;48.40&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				1.00&nbsp;&nbsp;&nbsp;&nbsp;2.11%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PREMIERLEA" class='abhead' target='_top'>
+											PREMIERLEA&nbsp;2.30&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.20&nbsp;&nbsp;&nbsp;&nbsp;-8.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PRIME1ICBA" class='abhead' target='_top'>
+											PRIME1ICBA&nbsp;4.70&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PRIMEBANK" class='abhead' target='_top'>
+											PRIMEBANK&nbsp;30.30&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;0.66%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PRIMEFIN" class='abhead' target='_top'>
+											PRIMEFIN&nbsp;3.20&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-3.03%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PRIMEINSUR" class='abhead' target='_top'>
+											PRIMEINSUR&nbsp;41.90&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.20&nbsp;&nbsp;&nbsp;&nbsp;-0.48%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PRIMELIFE" class='abhead' target='_top'>
+											PRIMELIFE&nbsp;44.40&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.30&nbsp;&nbsp;&nbsp;&nbsp;-0.67%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PRIMETEX" class='abhead' target='_top'>
+											PRIMETEX&nbsp;18.70&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				1.70&nbsp;&nbsp;&nbsp;&nbsp;10.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PROGRESLIF" class='abhead' target='_top'>
+											PROGRESLIF&nbsp;44.50&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.23%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PROVATIINS" class='abhead' target='_top'>
+											PROVATIINS&nbsp;54.80&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.50&nbsp;&nbsp;&nbsp;&nbsp;0.92%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="95" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PTL" class='abhead' target='_top'>
+											PTL&nbsp;&nbsp;&nbsp;63.80&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				1.00&nbsp;&nbsp;&nbsp;&nbsp;1.59%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PUBALIBANK" class='abhead' target='_top'>
+											PUBALIBANK&nbsp;36.90&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.40&nbsp;&nbsp;&nbsp;&nbsp;-1.07%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=PURABIGEN" class='abhead' target='_top'>
+											PURABIGEN&nbsp;31.70&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.60&nbsp;&nbsp;&nbsp;&nbsp;-1.86%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=QUASEMIND" class='abhead' target='_top'>
+											QUASEMIND&nbsp;43.70&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.30&nbsp;&nbsp;&nbsp;&nbsp;0.69%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=QUEENSOUTH" class='abhead' target='_top'>
+											QUEENSOUTH&nbsp;15.10&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.30&nbsp;&nbsp;&nbsp;&nbsp;2.03%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="135" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=RAHIMAFOOD" class='abhead' target='_top'>
+											RAHIMAFOOD&nbsp;102.40&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.40&nbsp;&nbsp;&nbsp;&nbsp;0.39%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=RAHIMTEXT" class='abhead' target='_top'>
+											RAHIMTEXT&nbsp;196.70&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.90&nbsp;&nbsp;&nbsp;&nbsp;-0.96%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=RAKCERAMIC" class='abhead' target='_top'>
+											RAKCERAMIC&nbsp;29.90&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.60&nbsp;&nbsp;&nbsp;&nbsp;2.05%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="135" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=RANFOUNDRY" class='abhead' target='_top'>
+											RANFOUNDRY&nbsp;154.40&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.00&nbsp;&nbsp;&nbsp;&nbsp;-0.64%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="110" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=RDFOOD" class='abhead' target='_top'>
+											RDFOOD&nbsp;28.60&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.30&nbsp;&nbsp;&nbsp;&nbsp;-1.04%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="140" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=RECKITTBEN" class='abhead' target='_top'>
+											RECKITTBEN&nbsp;3330.00&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				8.70&nbsp;&nbsp;&nbsp;&nbsp;0.26%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=REGENTTEX" class='abhead' target='_top'>
+											REGENTTEX&nbsp;6.80&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.70&nbsp;&nbsp;&nbsp;&nbsp;-9.33%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=RELIANCE1" class='abhead' target='_top'>
+											RELIANCE1&nbsp;10.60&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.20&nbsp;&nbsp;&nbsp;&nbsp;-1.85%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="135" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=RELIANCINS" class='abhead' target='_top'>
+											RELIANCINS&nbsp;113.10&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				1.90&nbsp;&nbsp;&nbsp;&nbsp;1.71%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=RENATA" class='abhead' target='_top'>
+											RENATA&nbsp;435.60&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				2.30&nbsp;&nbsp;&nbsp;&nbsp;0.53%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=RENWICKJA" class='abhead' target='_top'>
+											RENWICKJA&nbsp;537.30&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-2.30&nbsp;&nbsp;&nbsp;&nbsp;-0.43%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=REPUBLIC" class='abhead' target='_top'>
+											REPUBLIC&nbsp;35.30&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.40&nbsp;&nbsp;&nbsp;&nbsp;-1.12%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=RINGSHINE" class='abhead' target='_top'>
+											RINGSHINE&nbsp;3.90&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.30&nbsp;&nbsp;&nbsp;&nbsp;8.33%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="100" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ROBI" class='abhead' target='_top'>
+											ROBI&nbsp;&nbsp;&nbsp;31.40&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.40&nbsp;&nbsp;&nbsp;&nbsp;1.29%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=RSRMSTEEL" class='abhead' target='_top'>
+											RSRMSTEEL&nbsp;8.70&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.30&nbsp;&nbsp;&nbsp;&nbsp;3.57%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=RUNNERAUTO" class='abhead' target='_top'>
+											RUNNERAUTO&nbsp;42.00&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.30&nbsp;&nbsp;&nbsp;&nbsp;0.72%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=RUPALIBANK" class='abhead' target='_top'>
+											RUPALIBANK&nbsp;16.90&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=RUPALIINS" class='abhead' target='_top'>
+											RUPALIINS&nbsp;27.40&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.30&nbsp;&nbsp;&nbsp;&nbsp;-1.08%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=RUPALILIFE" class='abhead' target='_top'>
+											RUPALILIFE&nbsp;94.80&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.90&nbsp;&nbsp;&nbsp;&nbsp;-1.96%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SAFKOSPINN" class='abhead' target='_top'>
+											SAFKOSPINN&nbsp;19.90&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.90&nbsp;&nbsp;&nbsp;&nbsp;-4.33%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SAIFPOWER" class='abhead' target='_top'>
+											SAIFPOWER&nbsp;9.30&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.80&nbsp;&nbsp;&nbsp;&nbsp;9.41%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SAIHAMCOT" class='abhead' target='_top'>
+											SAIHAMCOT&nbsp;19.90&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.20&nbsp;&nbsp;&nbsp;&nbsp;-1.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SAIHAMTEX" class='abhead' target='_top'>
+											SAIHAMTEX&nbsp;18.60&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SALAMCRST" class='abhead' target='_top'>
+											SALAMCRST&nbsp;15.10&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.67%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="105" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SALVO" class='abhead' target='_top'>
+											SALVO&nbsp;&nbsp;&nbsp;37.40&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.30&nbsp;&nbsp;&nbsp;&nbsp;0.81%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="135" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SAMATALETH" class='abhead' target='_top'>
+											SAMATALETH&nbsp;106.10&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-2.10&nbsp;&nbsp;&nbsp;&nbsp;-1.94%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SAMORITA" class='abhead' target='_top'>
+											SAMORITA&nbsp;77.60&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				3.10&nbsp;&nbsp;&nbsp;&nbsp;4.16%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SANDHANINS" class='abhead' target='_top'>
+											SANDHANINS&nbsp;25.60&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SAPORTL" class='abhead' target='_top'>
+											SAPORTL&nbsp;60.50&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				2.00&nbsp;&nbsp;&nbsp;&nbsp;3.42%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SBACBANK" class='abhead' target='_top'>
+											SBACBANK&nbsp;6.50&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-1.52%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SEAPEARL" class='abhead' target='_top'>
+											SEAPEARL&nbsp;36.90&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;0.54%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SEMLFBSLGF" class='abhead' target='_top'>
+											SEMLFBSLGF&nbsp;5.40&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SEMLIBBLSF" class='abhead' target='_top'>
+											SEMLIBBLSF&nbsp;6.40&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;3.23%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SHAHJABANK" class='abhead' target='_top'>
+											SHAHJABANK&nbsp;17.00&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.59%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SHARPIND" class='abhead' target='_top'>
+											SHARPIND&nbsp;18.90&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				1.60&nbsp;&nbsp;&nbsp;&nbsp;9.25%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SHASHADNIM" class='abhead' target='_top'>
+											SHASHADNIM&nbsp;24.00&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;0.84%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SHEPHERD" class='abhead' target='_top'>
+											SHEPHERD&nbsp;16.70&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;1.21%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="110" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SHURWID" class='abhead' target='_top'>
+											SHURWID&nbsp;7.00&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;1.45%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SHYAMPSUG" class='abhead' target='_top'>
+											SHYAMPSUG&nbsp;186.40&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-12.60&nbsp;&nbsp;&nbsp;&nbsp;-6.33%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="100" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SICL" class='abhead' target='_top'>
+											SICL&nbsp;&nbsp;&nbsp;38.90&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.90&nbsp;&nbsp;&nbsp;&nbsp;-2.26%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SILCOPHL" class='abhead' target='_top'>
+											SILCOPHL&nbsp;22.10&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.80&nbsp;&nbsp;&nbsp;&nbsp;3.76%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SILVAPHL" class='abhead' target='_top'>
+											SILVAPHL&nbsp;14.20&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.70&nbsp;&nbsp;&nbsp;&nbsp;5.19%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="110" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SIMTEX" class='abhead' target='_top'>
+											SIMTEX&nbsp;25.60&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SINGERBD" class='abhead' target='_top'>
+											SINGERBD&nbsp;81.90&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.12%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SINOBANGLA" class='abhead' target='_top'>
+											SINOBANGLA&nbsp;54.80&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.70&nbsp;&nbsp;&nbsp;&nbsp;1.29%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="110" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SIPLC" class='abhead' target='_top'>
+											SIPLC&nbsp;&nbsp;&nbsp;102.80&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.50&nbsp;&nbsp;&nbsp;&nbsp;-1.44%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="140" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SJIBLPBOND" class='abhead' target='_top'>
+											SJIBLPBOND&nbsp;5220.00&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-200.00&nbsp;&nbsp;&nbsp;&nbsp;-3.69%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SKTRIMS" class='abhead' target='_top'>
+											SKTRIMS&nbsp;14.40&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.60&nbsp;&nbsp;&nbsp;&nbsp;4.35%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="135" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SONALIANSH" class='abhead' target='_top'>
+											SONALIANSH&nbsp;183.50&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.20&nbsp;&nbsp;&nbsp;&nbsp;-0.65%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SONALILIFE" class='abhead' target='_top'>
+											SONALILIFE&nbsp;84.10&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.70&nbsp;&nbsp;&nbsp;&nbsp;0.84%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="135" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SONALIPAPR" class='abhead' target='_top'>
+											SONALIPAPR&nbsp;231.40&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				3.00&nbsp;&nbsp;&nbsp;&nbsp;1.31%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SONARBAINS" class='abhead' target='_top'>
+											SONARBAINS&nbsp;44.90&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.30&nbsp;&nbsp;&nbsp;&nbsp;-0.66%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SONARGAON" class='abhead' target='_top'>
+											SONARGAON&nbsp;78.60&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-5.40&nbsp;&nbsp;&nbsp;&nbsp;-6.43%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SOUTHEASTB" class='abhead' target='_top'>
+											SOUTHEASTB&nbsp;9.90&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-1.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SPCERAMICS" class='abhead' target='_top'>
+											SPCERAMICS&nbsp;24.30&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.80&nbsp;&nbsp;&nbsp;&nbsp;3.40%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="100" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SPCL" class='abhead' target='_top'>
+											SPCL&nbsp;&nbsp;&nbsp;54.30&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SQUARETEXT" class='abhead' target='_top'>
+											SQUARETEXT&nbsp;49.10&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-0.20%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="135" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SQURPHARMA" class='abhead' target='_top'>
+											SQURPHARMA&nbsp;217.90&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				1.00&nbsp;&nbsp;&nbsp;&nbsp;0.46%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="110" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SSSTEEL" class='abhead' target='_top'>
+											SSSTEEL&nbsp;6.80&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.40&nbsp;&nbsp;&nbsp;&nbsp;6.25%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=STANCERAM" class='abhead' target='_top'>
+											STANCERAM&nbsp;72.50&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.30&nbsp;&nbsp;&nbsp;&nbsp;-0.41%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=STANDARINS" class='abhead' target='_top'>
+											STANDARINS&nbsp;52.50&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.60&nbsp;&nbsp;&nbsp;&nbsp;-1.13%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=STANDBANKL" class='abhead' target='_top'>
+											STANDBANKL&nbsp;4.80&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=STYLECRAFT" class='abhead' target='_top'>
+											STYLECRAFT&nbsp;53.10&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SUMITPOWER" class='abhead' target='_top'>
+											SUMITPOWER&nbsp;15.20&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.50&nbsp;&nbsp;&nbsp;&nbsp;3.40%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=SUNLIFEINS" class='abhead' target='_top'>
+											SUNLIFEINS&nbsp;67.50&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-4.70&nbsp;&nbsp;&nbsp;&nbsp;-6.51%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=TAKAFULINS" class='abhead' target='_top'>
+											TAKAFULINS&nbsp;38.90&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.60&nbsp;&nbsp;&nbsp;&nbsp;1.57%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=TALLUSPIN" class='abhead' target='_top'>
+											TALLUSPIN&nbsp;8.80&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.40&nbsp;&nbsp;&nbsp;&nbsp;4.76%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=TAMIJTEX" class='abhead' target='_top'>
+											TAMIJTEX&nbsp;128.50&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.00&nbsp;&nbsp;&nbsp;&nbsp;-0.77%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=TB10Y0434" class='abhead' target='_top'>
+											TB10Y0434&nbsp;107.41&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-2.28&nbsp;&nbsp;&nbsp;&nbsp;-2.08%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=TB10Y1135" class='abhead' target='_top'>
+											TB10Y1135&nbsp;101.72&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				1.13&nbsp;&nbsp;&nbsp;&nbsp;1.12%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=TB2Y0327" class='abhead' target='_top'>
+											TB2Y0327&nbsp;101.46&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.65&nbsp;&nbsp;&nbsp;&nbsp;0.64%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=TB2Y1026" class='abhead' target='_top'>
+											TB2Y1026&nbsp;100.59&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.02&nbsp;&nbsp;&nbsp;&nbsp;-0.02%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=TB5Y1229" class='abhead' target='_top'>
+											TB5Y1229&nbsp;105.05&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-1.57&nbsp;&nbsp;&nbsp;&nbsp;-1.47%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=TECHNODRUG" class='abhead' target='_top'>
+											TECHNODRUG&nbsp;42.50&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-0.23%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="105" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=TILIL" class='abhead' target='_top'>
+											TILIL&nbsp;&nbsp;&nbsp;54.20&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.70&nbsp;&nbsp;&nbsp;&nbsp;-1.28%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=TITASGAS" class='abhead' target='_top'>
+											TITASGAS&nbsp;17.70&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.20&nbsp;&nbsp;&nbsp;&nbsp;-1.12%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=TOSRIFA" class='abhead' target='_top'>
+											TOSRIFA&nbsp;20.90&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=TRUSTB1MF" class='abhead' target='_top'>
+											TRUSTB1MF&nbsp;3.10&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=TRUSTBANK" class='abhead' target='_top'>
+											TRUSTBANK&nbsp;15.60&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-0.64%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="110" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=TUNGHAI" class='abhead' target='_top'>
+											TUNGHAI&nbsp;3.10&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;3.33%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="90" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=UCB" class='abhead' target='_top'>
+											UCB&nbsp;&nbsp;&nbsp;9.10&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.30&nbsp;&nbsp;&nbsp;&nbsp;3.41%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="140" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=UNILEVERCL" class='abhead' target='_top'>
+											UNILEVERCL&nbsp;2053.00&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-7.20&nbsp;&nbsp;&nbsp;&nbsp;-0.35%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=UNIONCAP" class='abhead' target='_top'>
+											UNIONCAP&nbsp;4.80&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-2.04%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="120" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=UNIONINS" class='abhead' target='_top'>
+											UNIONINS&nbsp;40.10&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.90&nbsp;&nbsp;&nbsp;&nbsp;-2.20%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=UNIQUEHRL" class='abhead' target='_top'>
+											UNIQUEHRL&nbsp;41.30&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.20&nbsp;&nbsp;&nbsp;&nbsp;-0.48%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=UNITEDFIN" class='abhead' target='_top'>
+											UNITEDFIN&nbsp;15.60&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.30&nbsp;&nbsp;&nbsp;&nbsp;-1.89%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=UNITEDINS" class='abhead' target='_top'>
+											UNITEDINS&nbsp;43.50&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.70&nbsp;&nbsp;&nbsp;&nbsp;-1.58%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=UPGDCL" class='abhead' target='_top'>
+											UPGDCL&nbsp;125.00&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;0.16%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=USMANIAGL" class='abhead' target='_top'>
+											USMANIAGL&nbsp;45.20&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				1.20&nbsp;&nbsp;&nbsp;&nbsp;2.73%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=UTTARABANK" class='abhead' target='_top'>
+											UTTARABANK&nbsp;21.50&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-0.46%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=UTTARAFIN" class='abhead' target='_top'>
+											UTTARAFIN&nbsp;13.90&nbsp;<img src='assets/imgs/tkupdown.gif' border='0'>							   				<br>
+							   				0.00&nbsp;&nbsp;&nbsp;&nbsp;0.00%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=VAMLRBBF" class='abhead' target='_top'>
+											VAMLRBBF&nbsp;6.80&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;1.49%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="110" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=VFSTDL" class='abhead' target='_top'>
+											VFSTDL&nbsp;17.10&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.10&nbsp;&nbsp;&nbsp;&nbsp;0.59%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="130" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=WALTONHIL" class='abhead' target='_top'>
+											WALTONHIL&nbsp;380.90&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				3.80&nbsp;&nbsp;&nbsp;&nbsp;1.01%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=WATACHEM" class='abhead' target='_top'>
+											WATACHEM&nbsp;133.90&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-0.10&nbsp;&nbsp;&nbsp;&nbsp;-0.07%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=WMSHIPYARD" class='abhead' target='_top'>
+											WMSHIPYARD&nbsp;9.00&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.20&nbsp;&nbsp;&nbsp;&nbsp;2.27%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="95" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=YPL" class='abhead' target='_top'>
+											YPL&nbsp;&nbsp;&nbsp;24.90&nbsp;&nbsp;&nbsp;&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.30&nbsp;&nbsp;&nbsp;&nbsp;1.22%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="125" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ZAHEENSPIN" class='abhead' target='_top'>
+											ZAHEENSPIN&nbsp;6.10&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.30&nbsp;&nbsp;&nbsp;&nbsp;5.17%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="115" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ZAHINTEX" class='abhead' target='_top'>
+											ZAHINTEX&nbsp;9.00&nbsp;<img src='assets/imgs/tkup.gif' border='0'>							   				<br>
+							   				0.30&nbsp;&nbsp;&nbsp;&nbsp;3.45%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+											<td valign='top' height='30'>
+							<table width="135" border="0" cellspacing="0" cellpadding="0">
+								<tr>
+									<td height='30' width='100%'>
+										<a href="displayCompany.php?name=ZEALBANGLA" class='abhead' target='_top'>
+											ZEALBANGLA&nbsp;126.50&nbsp;<img src='assets/imgs/tkdown.gif' border='0'>							   				<br>
+							   				-2.70&nbsp;&nbsp;&nbsp;&nbsp;-2.09%	                       				</a>
+	                       				<br>
+          							</td>
+          						</tr>
+          					</table>
+	  					</td>
+      					<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+										</tr>
+					</table>
+				</marquee>
+			</div>
+			<div class="scroller-ticker">
+				<img id="IMG1" name="IMG1" src="assets/imgs/stop.gif" style="display:block" onClick="swapImagess();" width="10" height="11">
+				<img id="IMG2" name="IMG2" src="assets/imgs/fast.jpg" style="display:block" alt="Increase the speed of the ticker" onClick="swapImagespeed();" width="10" height="11">
+				<img id="IMG3" name="IMG3" style="display:block" src="assets/imgs/right.jpg" alt="Set the ticker's scrolling direction to right" onClick="swapImagedir();" width="10" height="12">
+			</div>
+		</div>
+	</div>
+	<div class="clearfix"></div>
+
+	<style type="text/css">
+.menucolor .nav-item .nav-link {
+	color: #fff !important;
+	font-size: 12px;
+}
+.nav>li>a {
+	padding: 5px 5px!important;
+}
+
+@media (min-width: 320px) {
+.navbar-nav .open .dropdown-menu>li>a {
+	font-size: 12px !important;
+}
+}
+
+@media screen and (min-width: 640px) {
+.mainmenu {
+	padding: 1px !important;
+}
+/*Off 18 january 2022*/
+        /*.navbar-nav .nav-item{
+            padding-right: 20px;
+        }*/
+
+        /*add 18 january 2022*/
+.navbar-nav .nav-item a {
+	padding-left: 15px !important;
+	padding-right: 15px !important;
+}
+.dropdown-menu>li>a {
+	padding-top: 5px !important;
+	padding-bottom: 5px !important;
+}
+}
+
+@media screen and (max-width: 640px) {
+.mainmenu {
+	margin-top: 35px !important;
+	/*padding: 15px !important;*/
+	padding-left: 15px !important;
+	padding-right: 15px !important;
+	border-bottom: 1px #dedede solid;
+}
+.navbar-nav .nav-link {
+	padding-left: 10px;
+	border-bottom: 1px #dedede solid;
+}
+.navbar-collapse {
+	border-top: 2px #dedede solid;
+}
+.mobile-version a {
+	padding-left: 5px;
+}
+}
+.navbar-toggler, .navbar-toggler:focus, .navbar-toggler:active, .navbar-toggler-icon:focus {
+	outline: none;
+	border: none;
+	box-shadow: none;
+}
+</style>
+<nav class="navbar navbar-expand-lg navbar-light bg-light mainmenu" style="background: linear-gradient(to bottom,#015f70 0,#004149 100%) !important;">
+<!-- <nav role="navigation" class="navbar navbar-default mainmenu"> -->
+<!-- Brand and toggle get grouped for better mobile display -->
+<!-- <span class="navbar-brand mobile-version"><a href="https://dsebd.org/amp" style="font-size: 14px;">Lite Version</a></span> -->
+
+<span class="mobile-version"><a href="https://dsebd.org/amp" style="font-size: 14px;">Lite Version</a></span> 
+<!-- <div class="navbar-header">
+        <button type="button" data-target="#navbarCollapse" data-toggle="collapse" class="navbar-toggle">
+            <span class="sr-only">Toggle navigation</span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+        </button>
+    </div> --> 
+<a class="navbar-brand" href="#"></a>
+<button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation"> <span class="navbar-toggler-icon"></span> </button>
+
+<!-- Collection of nav links and other content for toggling -->
+<div id="navbarCollapse" class="collapse navbar-collapse">
+<!-- <span class="mobile-version"><a href="//web1/dse">Switch to Light Version</a></span> -->
+
+<ul id="fresponsive" class="nav navbar-nav dropdown menucolor wh-sp-nw">
+<li class="active nav-item"><a class="nav-link" href="index.php">Home</a></li>
+<!-- <li class="nav-item dropdown">
+              <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                Dropdown
+              </a>
+              <ul class="dropdown-menu" aria-labelledby="navbarDropdown">
+                <li><a class="nav-link" href="ilf.php">Introduction to DSE</a></li>
+                <li><a class="dropdown-item" href="#">Action</a></li>
+                <li><a class="dropdown-item" href="#">Another action</a></li>
+                <li><hr class="dropdown-divider"></li>
+                <li><a class="dropdown-item" href="#">Something else here</a></li>
+              </ul>
+            </li> -->
+<li class="nav-item dropdown"> <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false" style="padding: 10px;"> About Us <b class="caret"></b> </a>
+  <ul class="dropdown-menu" aria-labelledby="navbarDropdown">
+    <li><a class="nav-link" href="ilf.php">Introduction to DSE</a></li>
+    <li><a class="nav-link" href="vision.php">Mission and Vision</a></li>
+    <li><a class="nav-link" href="dseglance.php">DSE at a Glance</a></li>
+    <li><a class="nav-link" href="directors.php">Board of Directors</a></li>
+    <li class="dropdown-submenu" aria-labelledby="navbarDropdown"> <a href="#" id="navbarDropdown" class="dropdown-toggle nav-link" data-bs-toggle="dropdown" aria-expanded="false">Board Committees<span class="caret"></a>
+      <ul class="dropdown-menu">
+        <li><a class="nav-link" href="committee_nomination.php">Nomination and Remuneration Committee</a></li>
+        <li><a class="nav-link" href="committee_regulatory.php">Regulatory Affairs Committee</a></li>
+        <li><a class="nav-link" href="committee_audit_risk_management.php">Audit and Risk Management Committee</a></li>
+        <li><a class="nav-link" href="committee_appeals.php">Appeals Committee</a></li>
+        <li><a class="nav-link" href="committee_conflict_mitigation.php">Conflict Mitigation Committee</a></li>
+        <li><a class="nav-link" href="committee_IT_Advisory.php">IT Advisory and Strategy Development Committee </a></li>
+      </ul>
+    </li>
+    <li><a class="nav-link" href="manag.php">DSE Management</a></li>
+    <li><a class="nav-link" href="president_chairmen_of_dse_with_photo.php">DSE Presidents/Chairmen</a></li>
+    <li><a class="nav-link" href="ilf.php#lc" >Legal Control</a></li>
+    <li><a class="nav-link" href="ilf.php#fnd" >Function of DSE</a></li>
+    <li><a class="nav-link" href="settle.php">Clearing &amp; Settlement</a></li>
+    <li class="dropdown-submenu"><a href="#" class="dropdown-toggle nav-link" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">DSE Indices <b class="caret"></b></a>
+      <ul class="dropdown-menu">
+        <li><a class="nav-link" href="assets/pdf/DSEX_DS30.pdf">Index developed by S&amp;P</a></li>
+        <li><a class="nav-link" href="assets/pdf/DSES.pdf">DSEX Shariah Index Methodology</a></li>
+        <li><a class="nav-link" href="dse_algorithm.php">Algorithm of DSE Indices</a></li>
+        <li><a class="nav-link" href="dseX_share.php">DSEX Index</a></li>
+        <li><a class="nav-link" href="dse30_share.php">DS30 Index</a></li>
+      </ul>
+    </li>
+    <li><a class="nav-link" href="hts.php">Holidays &amp; Trading Sessions</a></li>
+    <!--<li><a class="nav-link" href="presidents.php">DSE Presidents/Chairmen</a></li> -->
+    <li><a class="nav-link" href="dse_dept.php">Departments of DSE</a></li>
+    <li><a class="nav-link" href="search_member_with_branch.php">TREC Holders' Directory</a></li>
+    <!--<li><a class="nav-link" href="pdf/DSEATS.pdf">Automated Trading System</a></li>
+                <li><a class="nav-link" href="pdf/MandA.pdf">Memorandum & Articles of Association</a></li>-->
+    <li><a class="nav-link" href="surv.php">Surveillance</a></li>
+    <li><a class="nav-link" href="dse-annual-report.php">Annual Report</a></li>
+  </ul>
+</li>
+<li class="nav-item dropdown"> <a href="#" class="dropdown-toggle nav-link" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Market Updates <b class="caret"></b></a>
+  <ul class="dropdown-menu">
+    <li class="dropdown-submenu"><a href="#" class="dropdown-toggle nav-link" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Market Updates <b class="caret"></b></a>
+      <ul class="dropdown-menu">
+        <li><a class="nav-link" href="top_20_share.php">Top 20 Share</a></li>
+        <li><a class="nav-link" href="latest_share_price_scroll_l.php">Latest Share Price</a></li>
+      </ul>
+    </li>
+    <li><a class="nav-link" href="news_archive.php#lc">Valid Announcements</a></li>
+    <li><a class="nav-link" href="cbul.php">Circuit Breaker</a></li>
+    <li><a class="nav-link" href="top_ten_gainer.php">Top 10 Gainers</a></li>
+    <li><a class="nav-link" href="top_ten_loser.php">Top 10 Losers</a></li>
+    <li><a class="nav-link" href="market-statistics.php">Market Statistics</a></li>
+    <li><a class="nav-link" href="CompAGM&amp;RecordDate.php">Companies AGM/EGM and Record Date</a></li>
+    <li><a class="nav-link" href="recent_market_information.php">Recent Market Information</a></li>
+    <li><a class="nav-link" href="mrg.php">Monthly Reviews &amp; Graphs</a></li>
+    <li><a class="nav-link" href="Fortnightly_Capital_Market.php">Fortnightly Capital Market</a></li>
+    <li><a class="nav-link" href="markets.php">Comparison of Market</a></li>
+  </ul>
+</li>
+<li class="nav-item dropdown"> <a href="#" class="dropdown-toggle nav-link" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Rules &amp; Regulations <b class="caret"></b></a>
+  <ul class="dropdown-menu">
+    <li><a class="nav-link" href="trecregulation.php">TREC Regulations</a></li>
+    <li><a class="nav-link" href="Listing_rule.php">Listing Regulations</a></li>
+    <li><a class="nav-link" href="assets/pdf/DemuAct2013.pdf">The Exchanges Demutualization Act 2013 </a></li>
+    <li><a class="nav-link" href="assets/pdf/Demutualization Schme.pdf">Demutualization Scheme </a></li>
+    <li><a class="nav-link" href="assets/pdf/MandA.pdf">Memorandum and Articles of Association </a></li>
+    <li><a class="nav-link" href="Corporate_Governance_Code.php">Corporate Governance Code</a></li>
+    <li><a class="nav-link" href="settlementrule.php">Settlement Regulations</a></li>
+    <li><a class="nav-link" href="assets/pdf/SGF-7082014130507.pdf">Settlement Guarantee Fund Regulations-2013</a></li>
+    <li><a class="nav-link" href="https://www.dsebd.org/SettlementofDisputeRegulationse.php">Settlement of Dispute Regulations, 2026</a></li>
+    
+	<li><a class="nav-link" href="assets/pdf/shortSaleReg.pdf">Short-Sale Regulations-2006</a></li>
+    <li><a class="nav-link" href="assets/pdf/auto_trade.pdf">Automated Trading Regulations-99</a></li>
+    <li><a class="nav-link" href="ipfr.php">Investors Protection Fund Regulations</a></li>
+    <li><a class="nav-link" href="margin_rules.php">Margin Rules</a></li>
+    <li><a class="nav-link" href="memmarginregulation.php">TREC Holder Margin Regulations</a></li>
+    <li><a class="nav-link" href="boardadmin.php">Board and Administration Regulations</a></li>
+    <li><a class="nav-link" href="https://sec.gov.bd/home/laws" target="_blank">Securities Related Laws</a></li>
+  </ul>
+</li>
+<li class="nav-item dropdown"> <a href="#" class="dropdown-toggle nav-link" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Companies'/ Securities' Info <b class="caret"></b></a>
+  <ul class="dropdown-menu">
+    <li><a class="nav-link" href="company_listing.php">Listed Companies/ Securities</a></li>
+    <li><a class="nav-link" href="https://www.dsebd.org/Non_operational_Companies_info.php">Closed/Non-operational Companies</a></li>
+    <li><a class="nav-link" href="CompAGM&amp;RecordDate.php">Companies´ AGM/ EGM and Record Date</a></li>
+  <!--  <li><a class="nav-link" href="ipo.php">New Issues (IPO)</a></li>  -->
+    <li><a class="nav-link" href="rights_issue_utilisation.php">IPO/ RPO/ Rights Proceeds Utilisation</a></li>
+    <li class="dropdown-submenu"><a href="#" class="dropdown-toggle nav-link" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Marginable Securities <b class="caret"></b></a>
+      <ul class="dropdown-menu">
+        <li><a class="nav-link" href="marginable-securities.php">Margin Financeable Securities</a></li>
+        <li><a class="nav-link" href="latest_PE.php">P/E at a glance</a></li>
+        <li><a class="nav-link" href="sectoral_PE.php">Sectoral Median P/E</a></li>
+		  <li><a class="nav-link" href="going-concern-threat-list.php">Going Concern threat List</a></li>
+		  <li><a class="nav-link" href="actuarial-valuation-status.php">Actuarial Valuation Conduction Status</a></li>
+      </ul>
+    </li>
+    <li><a class="nav-link" href="financial-statement-submission-status-extended.php">Financial Statements Submission Status</a></li>
+  </ul>
+</li>
+<li class="nav-item dropdown"> <a href="#" class="dropdown-toggle nav-link" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Investor Guide<b class="caret"></b></a>
+  <ul class="dropdown-menu">
+    <li><a class="nav-link" href="genprof.php">General Profile of Bangladesh</a></li>
+    <li><a class="nav-link" href="ecobd.php">Economy of Bangladesh</a></li>
+    <li><a class="nav-link" href="mglc.php">Market at a Glance</a></li>
+    <li><a class="nav-link" href="assets/pdf/facilitiesForForeignInvestors.pdf">Opportunity for Foreign Investors</a></li>
+    <li><a class="nav-link" href="assets/pdf/facilitiesForNRB.pdf">Facilities for Non-resident Bangladeshis</a></li>
+    <!--<li><a class="nav-link" href="feu.php">Financial & Economical Updates</a></li>-->
+    <li><a class="nav-link" href="share_transfer_procedure.php">Process of Gift/ Transfer of Shares</a></li>
+    <li><a class="nav-link" href="dse_faq.php">FAQ</a></li>
+  </ul>
+</li>
+<li class="nav-item dropdown"> <a href="#" class="dropdown-toggle nav-link" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Listing <b class="caret"></b></a>
+  <ul class="dropdown-menu">
+    <li><a class="nav-link" href="benifits_of_listing.php">Benefits of Listing</a></li>
+    <li><a class="nav-link" href="why_dse_listing.php">Why List With DSE</a></li>
+    <li><a class="nav-link" href="why_dse_listing.php#methods">Methods of Listing</a></li>
+  <!--  <li><a class="nav-link" href="provision_for_listing.php">Provisions of Mandatory Listing</a></li>   -->
+    <li><a class="nav-link" href="criteria_for_listing.php">Eligibility Criteria for Listing</a></li>
+    <li><a class="nav-link" href="listing_procedure.php">Listing Procedure/Listing Guidebook</a></li>
+    <li><a class="nav-link" href="listing_timeline.php">Listing Time Line</a></li>
+	<li><a class="nav-link" href="Eligible_Investors.php">Eligible Investors (EIs)</a></li>
+    <!--<li><a href="#">Listing Center- Support Desk</a></li>
+                    <li><a href="#">Major Rules & Regulations for listing</a></li>
+    <li class="dropdown-submenu"> <a href="#" class="dropdown-toggle nav-link" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">New Public Offerings</a>
+      <ul class="dropdown-menu">
+        <li><a class="nav-link" href="fixedpriceipo.php">Fixed Price</a></li>
+        <li><a class="nav-link" href="bookbuildingipo.php">Book Building</a></li>
+        <li><a class="nav-link" href="directlisting.php">Direct Listing</a></li>
+      </ul>
+    </li>  
+    <li><a class="nav-link" href="rightoffers.php">Rights Offer</a></li>  -->
+    <li><a class="nav-link" href="listing_fees.php">Listing Fees</a></li>
+    <li><a class="nav-link" href="share_transfer_procedure.php">Share Transfer Process</a></li>
+    <li><a class="nav-link" href="listing_reg_2015.php">Formats Under Listing Regulation</a></li>
+    <!--li><a class="nav-link" href="complaintCell.php">E-Investor’s Complaint</a></li>
+                    <li><a class="nav-link" href="#">Downloads</a></li>
+                    <li><a class="nav-link" href="#">FAQs</a></li>   -->
+  </ul>
+</li>
+<li class="nav-item dropdown"> <a href="#" class="dropdown-toggle nav-link" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Products<b class="caret"></b></a>
+  <ul class="dropdown-menu">
+    <li><a class="nav-link" href="products_of_dse.php">Equity</a></li>
+    <li><a class="nav-link" href="products_of_dse.php#Debt">Debt</a></li>
+    <li><a class="nav-link" href="products_of_dse.php#FutureProd">Future Products</a></li>
+    <li class="dropdown-submenu"> <a href="#" class="dropdown-toggle nav-link" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">OMS Services</a>
+      <ul class="dropdown-menu">
+        <li><a class="nav-link" href="dse-mobile.php">DSE-Mobile Service</a></li>
+        <li><a class="nav-link" href="assets/pdf/BHOMS_Brochure_v1.1.pdf">API for BHOMS</a></li>
+      </ul>
+    </li>
+    <li class="dropdown-submenu"> <a href="#" class="dropdown-toggle nav-link" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">DSE Data Services</a>
+      <ul class="dropdown-menu">
+        <li><a class="nav-link" href="assets/pdf/Introduction of DSE Data Sale Services.pdf">Introduction</a></li>
+        <li><a class="nav-link" href="assets/pdf/iMDS.pdf">MDS</a></li>
+        <li><a class="nav-link" href="assets/pdf/EOD.pdf">EOD</a></li>
+      </ul>
+    </li>
+  </ul>
+</li>
+<li class="nav-item dropdown">
+<a href="#" class="dropdown-toggle nav-link" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">Sustainability<b class="caret"></b></a>
+<ul class="dropdown-menu">
+  <li><a class="nav-link" href="https://dsebd.org/GRI-about.php">About</a></li>
+  <li><a class="nav-link" href="https://dsebd.org/GRI-SSE-Initiatives.php">SSE Initiative Members</a></li>
+  <li class="dropdown-submenu"> <a href="#" class="dropdown-toggle nav-link" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">GRI</a>
+    <ul class="dropdown-menu">
+      <li><a class="nav-link" href="https://www.globalreporting.org/about-gri/gri-in-south-asia/" target="_blank">GRI Home Page</a></li>
+      <li><a class="nav-link" href="https://dsebd.org/assets/pdf/GRI/DSE-&-GRI-Collaborations.pdf">DSE and GRI Collaboration</a></li>
+      <li><a class="nav-link" href="https://dsebd.org/assets/pdf/GRI/Guidance-Document-for-Sustainability-Reporting-Based-On-GRI.pdf">Guidance on Reporting</a></li>
+      <li><a class="nav-link" href="https://dsebd.org/GRI-training.php">Training and Seminars</a></li>
+      <li><a class="nav-link" href="https://dsebd.org/GRI-Publication.php">Publications and Reporting</a></li>
+      <li><a class="nav-link" href="https://dsebd.org/GRI-Media.php">Media Coverage</a></li>
+    </ul>
+  <li><a class="nav-link" href="https://dsebd.org/GRI-ifc.php">IFC</a></li>
+  <li><a class="nav-link" href="https://dsebd.org/assets/pdf/GRI/dec312020sfd05.pdf" target="_blank">Bangladesh Bank Policy</a></li>
+  </li>
+</ul>
+<li class="nav-item"><a class="nav-link" href="contact.php">Contact Us</a></li>
+</div>
+</nav>
+</header>			</div>
+		</div>
+		<div class="clearfix"></div>
+
+		<section class="content">
+			<div class="gray">
+				<div class="col-md-2 LeftCol">				
+					<style type="text/css">
+a:link {
+	text-decoration: none;
+}
+a:visited {
+	text-decoration: none;
+}
+a:hover {
+	text-decoration: none;
+}
+a:active {
+	text-decoration: none;
+}
+</style>
+
+<div class="LeftBox">
+  <h2 class="LeftHeading">Market Highlights</h2>
+  <ul class="InLmenu">
+    <li><a href="mkt_depth_3.php">Market Price</a></li>
+    <li><a href="top_20_share.php">Top 20 Shares</a></li>
+    <li><a href="dseX_share.php">DSE<strong><font size="2">X &nbsp;</font></strong></a></li>
+    <li><a href="dse30_share.php">DS30</a></li>
+    <li><a href="news_archive.php">News</a></li>
+  </ul>
+</div>
+<div class="LeftBox">
+  <h2 class="LeftHeading">Latest Share Price</h2>
+  <ul class="InLmenu">
+    <li><a href="latest_share_price_scroll_l.php">By Trade Code</a></li>
+    <li><a href="latest_share_price_scroll_by_change.php">By % Change</a></li>
+    <li><a href="latest_share_price_scroll_by_value.php"> By Value</a></li>
+    <li><a href="latest_share_price_scroll_by_volume.php"> By Volume</a></li>
+    <li><a href="latest_share_price_scroll_by_ltp.php"> By Last Trade Price</a></li>
+    <li><a href="latest_share_price_scroll_group.php">By Category</a></li>
+    <li><a href="latest_share_price_alpha.php" target="_top">By Alphabetic Order</a></li>
+    <li><a href="https://www.dsebd.org/datafile/quotes_script.php" target="_blank">In Text Mode</a></li>
+    <li><a href="latest_share_price_scroll_treasury_bond.php">DEBT Board</a></li>
+    <li><a href="https://www.dsebd.org/government-securities.php">G-Sec</a></li>
+  </ul>
+</div>
+<div class="LeftBox">
+  <h2 class="LeftHeading">Search Company</h2>
+  <center>
+    <p>Enter Company's Trading code</p>
+    <!-- <form action="SearchCompany.php" method="submit" name="form" target="_top" onsubmit="return chkform();"> -->
+    <p class="imgSearchParent">
+      <input name="name" class="form-control textNumber textCompany" size="20" type="text">
+      <!-- <img src="assets/images/search.png" class="imgCompanySearch imgSearch" alt="S"> --> 
+    </p>
+    <p>
+      <input value="Submit" class="btn btn-primary btn-sm btnCompanySearch" name="btnCompanySearch" type="button">
+    </p>
+    <!-- </form> -->
+  </center>
+  <ul class="InLmenu">
+    <li><a href="company_listing.php">Company Listing</a></li>
+    <li><a href="by_industrylisting.php">Sector wise Company List</a></li>
+  </ul>
+</div>
+<div class="LeftBox">
+  <h2 class="LeftHeading">Search TREC Holder</h2>
+  <ul class="InLmenu">
+    <li><a href="list_of_member.php">By Alphabetic Order</a></li>
+    <li><a href="search_member_by_location.php">By Location</a></li>
+    <li><a href="search_member_with_branch.php">TREC Holders' Directory</a></li>
+  </ul>
+  <center>
+    <p>Enter TREC Holder Name</p>
+    <!-- <form method="POST" action="SearchCompany.php" name="form" onsubmit="return chkform();"> -->
+    <p class="imgSearchParent">
+      <input name="name" class="form-control textNumber textTRECHolder" size="20" type="text" >
+    </p>
+    <!-- <input name="ser_cat" value="member" type="hidden"><br> -->
+    <p>
+      <input value="Submit" class="btn btn-primary btn-sm btnTRECHolderSearch" name="btnCompanySearch2" type="button">
+    </p>
+    <!-- </form> -->
+  </center>
+</div>
+<div class="LeftBox">
+  <h2 class="LeftHeading">Market Information</h2>
+  <ul class="InLmenu">
+    <li><a href="cbul.php">Circuit Breaker</a></li>
+    <li><a href="recent_market_information.php">Recent Market Information</a></li>
+    <li><a href="data_archive.php">Data Archive</a></li>
+    <li><a href="weekly_report.pdf">Weekly Report</a></li>
+  </ul>
+</div>
+<div class="LeftBox">
+  <h2 class="LeftHeading">Day End Statistics</h2>
+  <ul class="InLmenu">
+    <li><a href="market-statistics.php">Market Statistics</a></li>
+    <li><a href="top_ten_gainer.php">Top 10 Gainers</a></li>
+    <li><a href="top_ten_loser.php">Top 10 Losers</a></li>
+    <li><a href="dse_close_price.php">Close Price</a></li>
+    <li><a href="latest_PE.php">P/E at a glance</a></li>
+    <!--li><a href="assets/pdf/marginable-securities.pdf">Margin Financeable Securities</a></li-->
+    <li><a href="marginable-securities.php">Margin Financeable Securities</a></li>
+  </ul>
+</div>
+<table width="100%" cellspacing="2" cellpadding="0" border="0">
+  <tbody>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="Training_Academy_2.b.php"> DSE Training Academy </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="otc.php"> OTC Market </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="vision.php"> Vision &amp; Mission </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="dse_tower_progress.php"> DSE Tower Progress </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="dseglance.php"> DSE at a glance </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="press.php"> Press Release </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="picture_gallery.php"> Picture Gallery </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="ipo.php"> IPO </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="new.php"> Major Events </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="rightoffers.php"> Rights Offer Document </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="directlisting.php"> Direct Listing </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="cdbl.php"> CDBL </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="inquirydesk.php"> Inquiry Desk </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="complaintCell.php"> Complaint Cell </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="helpdesk_nrb.php"> Helpdesk for NRB </a></td>
+    </tr>
+  </tbody>
+</table>
+				</div>
+
+				<div id="mySidenav" class="sidenav">
+				 	<a href="javascript:void(0)" class="closebtn" onclick="closeNav()">&times;</a>
+					<style type="text/css">
+a:link {
+	text-decoration: none;
+}
+a:visited {
+	text-decoration: none;
+}
+a:hover {
+	text-decoration: none;
+}
+a:active {
+	text-decoration: none;
+}
+</style>
+
+<div class="LeftBox">
+  <h2 class="LeftHeading">Market Highlights</h2>
+  <ul class="InLmenu">
+    <li><a href="mkt_depth_3.php">Market Price</a></li>
+    <li><a href="top_20_share.php">Top 20 Shares</a></li>
+    <li><a href="dseX_share.php">DSE<strong><font size="2">X &nbsp;</font></strong></a></li>
+    <li><a href="dse30_share.php">DS30</a></li>
+    <li><a href="news_archive.php">News</a></li>
+  </ul>
+</div>
+<div class="LeftBox">
+  <h2 class="LeftHeading">Latest Share Price</h2>
+  <ul class="InLmenu">
+    <li><a href="latest_share_price_scroll_l.php">By Trade Code</a></li>
+    <li><a href="latest_share_price_scroll_by_change.php">By % Change</a></li>
+    <li><a href="latest_share_price_scroll_by_value.php"> By Value</a></li>
+    <li><a href="latest_share_price_scroll_by_volume.php"> By Volume</a></li>
+    <li><a href="latest_share_price_scroll_by_ltp.php"> By Last Trade Price</a></li>
+    <li><a href="latest_share_price_scroll_group.php">By Category</a></li>
+    <li><a href="latest_share_price_alpha.php" target="_top">By Alphabetic Order</a></li>
+    <li><a href="https://www.dsebd.org/datafile/quotes_script.php" target="_blank">In Text Mode</a></li>
+    <li><a href="latest_share_price_scroll_treasury_bond.php">DEBT Board</a></li>
+    <li><a href="https://www.dsebd.org/government-securities.php">G-Sec</a></li>
+  </ul>
+</div>
+<div class="LeftBox">
+  <h2 class="LeftHeading">Search Company</h2>
+  <center>
+    <p>Enter Company's Trading code</p>
+    <!-- <form action="SearchCompany.php" method="submit" name="form" target="_top" onsubmit="return chkform();"> -->
+    <p class="imgSearchParent">
+      <input name="name" class="form-control textNumber textCompany" size="20" type="text">
+      <!-- <img src="assets/images/search.png" class="imgCompanySearch imgSearch" alt="S"> --> 
+    </p>
+    <p>
+      <input value="Submit" class="btn btn-primary btn-sm btnCompanySearch" name="btnCompanySearch" type="button">
+    </p>
+    <!-- </form> -->
+  </center>
+  <ul class="InLmenu">
+    <li><a href="company_listing.php">Company Listing</a></li>
+    <li><a href="by_industrylisting.php">Sector wise Company List</a></li>
+  </ul>
+</div>
+<div class="LeftBox">
+  <h2 class="LeftHeading">Search TREC Holder</h2>
+  <ul class="InLmenu">
+    <li><a href="list_of_member.php">By Alphabetic Order</a></li>
+    <li><a href="search_member_by_location.php">By Location</a></li>
+    <li><a href="search_member_with_branch.php">TREC Holders' Directory</a></li>
+  </ul>
+  <center>
+    <p>Enter TREC Holder Name</p>
+    <!-- <form method="POST" action="SearchCompany.php" name="form" onsubmit="return chkform();"> -->
+    <p class="imgSearchParent">
+      <input name="name" class="form-control textNumber textTRECHolder" size="20" type="text" >
+    </p>
+    <!-- <input name="ser_cat" value="member" type="hidden"><br> -->
+    <p>
+      <input value="Submit" class="btn btn-primary btn-sm btnTRECHolderSearch" name="btnCompanySearch2" type="button">
+    </p>
+    <!-- </form> -->
+  </center>
+</div>
+<div class="LeftBox">
+  <h2 class="LeftHeading">Market Information</h2>
+  <ul class="InLmenu">
+    <li><a href="cbul.php">Circuit Breaker</a></li>
+    <li><a href="recent_market_information.php">Recent Market Information</a></li>
+    <li><a href="data_archive.php">Data Archive</a></li>
+    <li><a href="weekly_report.pdf">Weekly Report</a></li>
+  </ul>
+</div>
+<div class="LeftBox">
+  <h2 class="LeftHeading">Day End Statistics</h2>
+  <ul class="InLmenu">
+    <li><a href="market-statistics.php">Market Statistics</a></li>
+    <li><a href="top_ten_gainer.php">Top 10 Gainers</a></li>
+    <li><a href="top_ten_loser.php">Top 10 Losers</a></li>
+    <li><a href="dse_close_price.php">Close Price</a></li>
+    <li><a href="latest_PE.php">P/E at a glance</a></li>
+    <!--li><a href="assets/pdf/marginable-securities.pdf">Margin Financeable Securities</a></li-->
+    <li><a href="marginable-securities.php">Margin Financeable Securities</a></li>
+  </ul>
+</div>
+<table width="100%" cellspacing="2" cellpadding="0" border="0">
+  <tbody>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="Training_Academy_2.b.php"> DSE Training Academy </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="otc.php"> OTC Market </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="vision.php"> Vision &amp; Mission </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="dse_tower_progress.php"> DSE Tower Progress </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="dseglance.php"> DSE at a glance </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="press.php"> Press Release </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="picture_gallery.php"> Picture Gallery </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="ipo.php"> IPO </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="new.php"> Major Events </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="rightoffers.php"> Rights Offer Document </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="directlisting.php"> Direct Listing </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="cdbl.php"> CDBL </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="inquirydesk.php"> Inquiry Desk </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="complaintCell.php"> Complaint Cell </a></td>
+    </tr>
+    <tr id="inleft" align="left">
+      <td colspan="2" valign="left" width="160" align="left"><a id="inleft" href="helpdesk_nrb.php"> Helpdesk for NRB </a></td>
+    </tr>
+  </tbody>
+</table>
+				</div>
+
+				<div id="RightBody" class="col-md-10 RightColmInner">
+					<span class="mobileleftmenu" onclick="openNav()">&#9776;open</span>
+
+                    <div class="row">
+                        <div class="col-md-12 col-sm-12 col-xs-12 searchArea">
+                        	<h2 class='BodyHead topBodyHead'>News for: ACI</h2>						    <!-- <div class="ads-block">
+						        <script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+						         LeaderboardPreview 
+						        <ins class="adsbygoogle"
+						             style="display:inline-block;width:728px;height:90px"
+						             data-ad-client="ca-pub-2209070014716943"
+						             data-ad-slot="7922174918"></ins>
+						        <script>
+						        (adsbygoogle = window.adsbygoogle || []).push({});
+						        </script>
+						    </div> -->
+							<div class="table-responsive">
+						        <style>
+						        .table-news{
+						            width: 100%
+						        }
+						        .table-news th{
+						            color: #3366FF;
+						        }
+						        p.titleHead{
+						            text-align: center;
+						            margin-top: 20px;
+						        }
+						        </style>
+
+								<table class='table-news'>
+						            						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Q3 Financials</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>(Continuation news of ACI): On the other hand, cost of borrowing increased due to additional funding for working capital and strategic investments for supporting business growth. Overall, the consolidated EPS was Taka (4.18) during the period against Taka (9.11) of SPLY. NOCFPS during the period was Taka (68.02) against Taka (83.14) as a result of the movement in the working capital. (end)</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2026-04-30</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Q3 Financials</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>(Continuation news of ACI): Reasons for significant deviations: During the nine months ended on 31 March 2026, the Group achieved a 15% revenue growth which was contributed by a number of businesses as demonstrated in Consolidated Operating Segments in Annexure A. During the period, increase in gross profit exceeded the increase in operating expenses driven by growth in key segments. (cont.2)</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2026-04-30</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Q3 Financials</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>(Q3 Un-audited): Consolidated EPS was Tk. (4.91) for January-March 2026 as against Tk. (1.12) for January-March 2025; Consolidated EPS was Tk. (4.18) for July 2025-March 2026 as against Tk. (9.11) for July 2024-March 2025. Consolidated NOCFPS was Tk. (68.02) for July 2025-March 2026 as against Tk. (83.14) for July 2024-March 2025. Consolidated NAV per share was Tk. 85.78 as on March 31, 2026 and Tk. 91.64 as on June 30, 2025. (cont.1)</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2026-04-30</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Board approval for the formation of a joint-venture company</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>The company has informed that the Board of Directors of the Company in its meeting held on 29 April 2026 approved the formation of a joint-venture company under the title of "Deli ACI Bangladesh Limited" having an authorized capital of BDT 100 (One Hundred) Crore and a paid up capital of BDT 27 (Twenty-Seven) Crore wherein Advanced Chemical Industries PLC shall hold 50% shares, subject to the approval of the concerned authority.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2026-04-30</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Board Meeting schedule under LR 16(1)</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>As per Regulation 16(1) of the Dhaka Stock Exchange (Listing) Regulations, 2015, the Company has informed that a meeting of the Board of Directors will be held on April 29, 2026 at 4:00 pm to consider, among others, Un-Audited Financial Statements for the Third Quarter (Q3) period ended March 31, 2026.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2026-04-22</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Buy Confirmation of Managing Director</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>Dr. Arif Dowla, Managing Director of the company, has further informed that he has completed his buying of 302,000 shares of the company at prevailing market price through Dhaka Stock Exchange PLC. as per declaration disseminated on 09.04.2026.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2026-04-21</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Buy Declaration of Managing Director</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>Dr. Arif Dowla, Managing Director of the company, has expressed his intention to buy 302,000 shares of the company at prevailing market price (in the Block Market) through Dhaka Stock Exchange PLC. within April 30, 2026 pursuant to the Regulation 34(1) of the Dhaka Stock Exchange (Listing) Regulations, 2015, as well as Rule 4 of the BSEC (Ullekhzogyo Sonkhyok Share Orjon, Odhigrohon o Kortritto Grohon) Bidhimala, 2018.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2026-04-09</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Board approval for an investment of BDT 640 Crore in ACI Logistics Limited</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>(Cont. News of ACI): The investment will be made on or before 31 March 2026, subject to the approval of the concerned authorities. (end)</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2026-02-01</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Board approval for an investment of BDT 640 Crore in ACI Logistics Limited</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>The company has informed that the Board of Directors of the Company, at its meeting held on 29 January 2026 has approved an investment of BDT 640 Crore in ACI Logistics Limited, a subsidiary of the Company. The investment will be made through the subscription of 6,400,000 (Six Million Four Hundred Thousand) convertible preference shares of BDT 1,000/- (BDT One Thousand) each, to be issued by ACI Logistics Limited. (cont.)</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2026-02-01</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Board approval for the formation and establishment of an institution</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>The company has informed that the Board of Directors of the Company, at its meeting held on 29 January 2026 approved the formation and establishment of an institution under the name and title "ACI Institution of Artificial Intelligence" with an initial investment of BDT 5 (Five) Crore, subject to the approval of the concerned authorities.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2026-02-01</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Q2 Financials</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>(Cont. News of ACI): On the other hand, cost of borrowing increased due to the increase of interest rate along with the additional funding for working capital and strategic investments for supporting business growth. Overall, the consolidated EPS was Taka 0.73 during the period against Taka (7.99) of SPLY. NOCFPS during the period was Taka (50.50) against Taka (63.60) as a result of the movement in the working capital. (end)</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2026-02-01</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Q2 Financials</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>(Cont. News of ACI): Reasons for deviation: During the half yearly ended on 31 December 2025, the Group achieved a 18% revenue growth which was contributed by a number of businesses as demonstrated in Consolidated Operating Segments. During the period, increase in gross profit exceeded the increase in operating expenses driven by growth in key segments. (cont.2)</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2026-02-01</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Q2 Financials</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>(Q2 Un-audited): Consolidated EPS was Tk. 0.34 for October-December 2025 as against Tk. (3.17) for October-December 2024; Consolidated EPS was Tk. 0.73 for July-December 2025 as against Tk. (7.99) for July-December 2024. Consolidated NOCFPS was Tk. (50.50) for July-December 2025 as against Tk. (63.60) for July-December 2024. Consolidated NAV per share was Tk. 90.70 as on December 31, 2025 and Tk. 91.64 as on June 30, 2025. (cont.1)</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2026-02-01</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Dividend Disbursement</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>The Company has informed that it has disbursed the Cash Dividend for the year ended June 30, 2025 to the respective shareholders.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2026-01-28</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Credit Rating Result</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>Credit Rating Information and Services PLC (CRISL) has assigned rating of the Company as "AA-" in the long term and "ST-2" in the short term along with Stable outlook in consideration of its audited financials up to June 30, 2025, also unaudited financials up to September 30, 2025 and other relevant quantitative as well as qualitative information up to the date of rating declaration.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2026-01-25</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Board Meeting schedule under LR 16(1)</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>As per Regulation 16(1) of the Dhaka Stock Exchange (Listing) Regulations, 2015, the Company has informed that a meeting of the Board of Directors will be held on January 29, 2026 at 4:00 PM to consider, among others, Un-Audited Financial Statements for the Second Quarter (Q2) period ended December 31, 2025.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2026-01-21</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Board approval for formation of a new subsidiary 'ACI Semiconductor Ltd.'</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>The company has informed that the Board of Directors of the Company, at its 227th Board meeting held on 15 January 2026, approved the formation of a new subsidiary company under the title of "ACI Semiconductor Limited" having an authorized capital of BDT 100 (One Hundred) Crore and a paid up capital of BDT 10 (Ten) Crore wherein Advanced Chemical Industries PLC shall hold 85% shares, subject to the approval of the concerned authority.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2026-01-18</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Board approval for formation of a new subsidiary 'ACI Properties Ltd.'</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>The company has informed that the Board of Directors of the Company, at its 227th Board meeting held on 15 January 2026, approved the formation of a new subsidiary company under the title of "ACI Properties Limited" having an authorized capital of BDT 100 (One Hundred) Crore and a paid up capital of BDT 10 (Ten) Crore wherein Advanced Chemical Industries PLC shall hold 85% shares, subject to the approval of the concerned authority.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2026-01-18</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Buy Confirmation of a Director</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>Ms. Shusmita Anis, a Director of the Company, has completed her buying of 1,60,000 shares of the Company at prevailing market price through Dhaka Stock Exchange PLC. as per declaration disseminated on 24.12.2025.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2026-01-07</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Buy Declaration of a Director</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>Ms. Shusmita Anis, a Director of the Company, has expressed her intention to buy 1,60,000 shares of the Company at prevailing market price (in the Block Market) through Dhaka Stock Exchange PLC. within next 30 working days.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2025-12-24</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Buy Confirmation of Chairman</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>Mr. M. Anis Ud Dowla, Chairman of the company, has further informed that he has completed his buying of 360,000 shares of the company at the prevailing market price through Dhaka Stock Exchange PLC. as per declaration disseminated on 27.11.2025.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2025-12-11</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Buy Declaration of Chairman</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>Mr. M. Anis Ud Dowla, Chairman of the company, has expressed his intention to buy 360,000 shares of the company at the prevailing market price (in the Block Market) through Dhaka Stock Exchange PLC. within next 30 (thirty) working days pursuant to Regulation 34(1) of the Dhaka Stock Exchange (Listing) Regulations, 2015, as well as Rule 4 of the BSEC (Ullekhzogyo Sonkhyok Share Orjon, Odhigrohon o Kortritto Grohon) Bidhimala, 2018.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2025-11-27</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Resumption after Record Date</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>Trading of the shares of the company will resume on 20.11.2025.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2025-11-19</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Suspension for Record Date</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>Trading of the shares of the company will remain suspended on record date i.e., 19.11.2025.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2025-11-18</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Spot News</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>Trading of the shares of the company will be allowed only in the Spot Market and Block transaction will also be settled as per spot settlement cycle with cum benefit from 17.11.2025 to 18.11.2025 and trading of the shares will remain suspended on record date i.e., 19.11.2025.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2025-11-16</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Q1 Financials</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>(Cont. News of ACI): Overall, the consolidated EPS was Taka 0.39 during the period against Taka (4.82) of SPLY. NOCFPS during the period was Taka (40.69) against Taka (54.00) as a result of the movement in the working capital. (end)</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2025-11-13</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Q1 Financials</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>(Cont. News of ACI): the Group achieved a 24.40% revenue growth which was contributed by a number of businesses as demonstrated in Consolidated Operating Segments. During the period, increase in gross profit exceeded the increase in operating expenses driven by growth in key segments. On the other hand, cost of borrowing increased due to the increase of interest rate along with the additional funding for working capital and strategic investments for supporting business growth. (cont.2)</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2025-11-13</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Q1 Financials</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>(Q1 Un-audited): Consolidated EPS was Tk. 0.39 for July-September 2025 as against Tk. (4.82) for July-September 2024. Consolidated NOCFPS was Tk. (40.69) for July-September 2025 as against Tk. (54.00) for July-September 2024. Consolidated NAV per share was Tk. 93.24 as on September 30, 2025 and Tk. 91.64 as on June 30, 2025. Reasons for significant deviations: During the 1st quarter ended on 30 September 2025, (cont.1)</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2025-11-13</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Buy Confirmation of Chairman</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>M. Anis Ud Dowla, Chairman of the Company, has further informed that he has completed his buying of 5,00,000 shares of the company at prevailing market price through Dhaka Stock Exchange PLC. as per declaration disseminated on 30.10.2025.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2025-11-10</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Board Meeting schedule under LR 16(1)</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>As per Regulation 16(1) of the Dhaka Stock Exchange (Listing) Regulations, 2015, the Company has informed that a meeting of the Board of Directors will be held on November 12, 2025 at 4:00 PM to consider, among others, Un-audited financial statements of the Company for the First Quarter (Q1) period ended September 30, 2025.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2025-11-09</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Dividend Declaration (Additional Information)</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>Refer to the earlier news disseminated by DSE on 29.10.2025 regarding dividend declaration, the company has further informed that the recommended 25% Cash Dividend is from its retained earnings for the year ended June 30, 2025. The declared dividend has not been recommended from capital reserve or revaluation reserve or any unrealized gain of the Company or through reducing the paid-up capital.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2025-10-30</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Buy Declaration of Chairman</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>Mr. M. Anis Ud Dowla, Chairman of the company, has expressed his intention to buy 500,000 shares of the company at prevailing market price (in the Block Market) through Dhaka Stock Exchange PLC. within next 30 (thirty) working days as per Rule-4 of the BSEC (Ullekhzogyo Sonkhyok Share Orjon, Odhigrohon o Kortritto Grohon) Bidhimala, 2018.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2025-10-30</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Price Limit Open</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>There will be no price limit on the trading of the shares of the Company today (29.10.2025) following its corporate declaration.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2025-10-29</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Dividend Declaration</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>(cont. news of ACI): On the other hand, cost of borrowings increased due to the increase of the interest rate along with additional funding for working capital and strategic investments for supporting business growth. Overall, the consolidated EPS was Taka (7.40) during the period against Taka (15.88) of SPLY. NOCFPS during the period was Taka (51.63) against Taka 0.71 mainly as a result of the investment in working capital. (end)</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2025-10-29</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Dividend Declaration</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>(cont. news of ACI): for the year ended June 30, 2024. Reasons for significant deviation: During the year, the Company achieved a 10.93% growth in consolidated revenue and a 15.42% increase in consolidated gross profit. The growth in gross profit exceeded the growth in operating expenses due to cost control initiatives which contributed to the improvement of the operating profit. (cont.2)</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2025-10-29</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Dividend Declaration</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>The Board of Directors has recommended 25% Cash Dividend for the year ended June 30, 2025. Date of AGM: 28.12.2025, Time: 11:30 AM, Venue: Digital System. Record Date: 19.11.2025. The Company has also reported Consolidated EPS of Tk. (7.40), Consolidated NAV per share of Tk. 91.64 and Consolidated NOCFPS of Tk. (51.63) for the year ended June 30, 2025 as against Consolidated EPS of Tk. (15.88), Consolidated NAV per share of Tk. 79.31 and Consolidated NOCFPS of Tk. 0.71 (cont.1)</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2025-10-29</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Board Meeting schedule under LR 19(1)</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>As per Regulation 19(1) of the Dhaka Stock Exchange (Listing) Regulations, 2015, the Company has informed that a meeting of the Board of Directors will be held on October 28, 2025 at 4:00 PM to consider, among others, audited financial statements of the Company for the year ended June 30, 2025.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2025-10-20</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Board approval for formation of a new subsidiary company</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>The company has informed that the Board of Directors of the Company at its 224th Board meeting held on 28 July 2025 approved the formation of a new subsidiary company under the name of "ACI Biosciences Limited" having an authorized capital of BDT 100 (One Hundred) Crore and a paid up capital of BDT 25 (Twenty Five) Crore wherein Advanced Chemical Industries PLC shall hold 90% shares, at the earliest convenience, subject to the approval of the concerned authority.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2025-07-29</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Name Change of the Company</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>Dhaka Stock Exchange PLC. (DSE) has approved the proposed name change of the Company. Accordingly, the name of the Company will be 'Advanced Chemical Industries PLC' instead of 'Advanced Chemical Industries Limited' with effect from June 26, 2025. Other information (except name) will remain unchanged.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2025-06-25</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Resumption after Record Date</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>Trading of the shares of the company will resume on 18.06.2025 with Adjusted Open Price following the record date for effecting the amalgamation scheme.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2025-06-17</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Suspension for Record Date</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>Trading of the shares of the company will remain suspended on record date i.e., 17.06.2025 for amalgamation purpose.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2025-06-16</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Spot News</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>Trading of the shares of the company will be allowed only in the Spot Market and Block transactions will also be settled as per spot settlement cycle with cum benefit from 15.06.2025 to 16.06.2025, and trading of the shares will remain suspended on record date i.e., 17.06.2025 for issuance and allotment of 195,374 shares.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2025-06-04</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Fixation of Record Date for issuance and allotment of 195,374 shares</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>(Cont. news of ACI): Name of the Shareholders and Quantity of Ordinary Shares are as follows: 1. Mr. M Anis Ud Dowla - 194,989 shares, 2. Dr. Arif Dowla - 195 shares and 3. Ms. Shusmita Anis - 190 shares. For such issue and allotment, the Record Date will be June 17, 2025. No of outstanding Shares of ACI Ltd.: Before Amalgamation: 87,636,469 shares and After Amalgamation: 87,831,843 shares (end)</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2025-05-25</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Fixation of Record Date for issuance and allotment of 195,374 shares</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>Referring to their earlier news disseminated by DSE on 08.05.2025, the company has further informed that following the Judgement passed in the Company Matter No. 272 of 2022 on November 07, 2023 by the Honorable High Court Division, 195,374 nos. of ordinary shares of Tk. 10/- (Taka Ten) each only will be issued and allotted in favour of the equity shareholders of Premiaflex Plastics Limited. (cont.)</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2025-05-25</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: BSEC's consent on the issue and allotment of 195,374 ordinary shares</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>(Cont. news of ACI): as per the Scheme of amalgamation approved by the shareholders and the Honorable High Court Division of the Supreme Court of Bangladesh, pursuant to Court Order in Company Matter No. 272 of 2022. (end)</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2025-05-08</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: BSEC's consent on the issue and allotment of 195,374 ordinary shares</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>Refer to their earlier news disseminated by DSE on 19.11.2024 regarding issuing of Shares and Raising Authorized Capital. In this respect, the Bangladesh Securities and Exchange Commission has accorded its consent for raising of paid-up capital by Advanced Chemical Industries Ltd by issuing 1,95,374 nos of ordinary shares @ Tk. 10/- each only in favor of the equity shareholders of Premiaflex Plastics Ltd (cont.)</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2025-05-08</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Q3 Financials</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>(Q3 Un-audited): Consolidated EPS was Tk. (1.12) for January-March 2025 as against Tk. 0.13 for January-March 2024; Consolidated EPS was Tk. (9.11) for July 2024-March 2025 as against Tk. (7.18) for July 2023-March 2024. Consolidated NOCFPS was Tk. (83.11) for July 2024-March 2025 as against Tk. (51.03) for July 2023-March 2024. Consolidated NAV per share was Tk. 67.10 as on March 31, 2025 and Tk. 79.28 as on June 30, 2024.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2025-04-30</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Buy Confirmation of Managing Director</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>Dr. Arif Dowla, Managing Director of the company, has further informed that he has completed his buying of 1,400,000 shares of the company at prevailing market price through Dhaka Stock Exchange PLC. as per declaration disseminated by DSE on 17.04.2025</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2025-04-28</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Buy Confirmation of a Director</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>Ms. Shusmita Anis, one of the Directors of the Company, has further informed that she has completed her buying of 775,000 shares of the company at prevailing market price through Dhaka Stock Exchange PLC. as per declaration disseminated on 13.04.2025.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2025-04-22</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Board Meeting schedule under LR 16(1)</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>As per Regulation 16(1) of the Dhaka Stock Exchange (Listing) Regulations, 2015, the Company has informed that a meeting of the Board of Directors will be held on April 29, 2025 at 4:00 PM to consider, among others, un-audited financial statements of the Company for the Third Quarter (Q3) period ended March 31, 2025.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2025-04-21</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Buy Declaration of Managing Director</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>Dr. Arif Dowla, Managing Director of the company, has expressed his intention to buy 1,400,000 shares of the company at prevailing market price (in the Block Market) through Dhaka Stock Exchange PLC. within April 30, 2025 as per Rule-4 of the BSEC (Ullekhzogyo Sonkhyok Share Orjon, Odhigrohon o Kortritto Grohon) Bidhimala, 2018.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2025-04-17</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Buy Declaration of a Director</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>Ms. Shusmita Anis, a Director of the Company, has expressed her intention to buy 775,000 shares of the Company at prevailing market price (in the Block Market) through Dhaka Stock Exchange PLC. within April 30, 2025.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2025-04-13</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Buy confirmation of Managing Director</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>Dr. Arif Dowla, Managing Director of the Company, has completed buying of 2,500,000 shares of the company through Dhaka Stock Exchange PLC. as per declaration disseminated on 10.02.2025.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2025-03-06</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Buy Declaration of Managing Director</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>Dr. Arif Dowla, Managing Director of the Company, has expressed his intention to buy 2,500,000 shares of the Company at prevailing market price (in the Block Market) through Dhaka Stock Exchange PLC. within next 30 working days.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2025-02-10</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Dividend Disbursement</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>The Company has informed that it has disbursed the Cash Dividend for the year ended June 30, 2024 to the respective shareholders.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2025-02-09</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Regarding Board approval of formation of a new subsidiary company</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>The company has informed that the Board of Directors of the Company in its meeting held on January 30, 2025 has approved the formation of a new subsidiary company under the title of "ACI Herbal and Nutraceuticals Limited" having an authorized capital of BDT 100 (One Hundred) Crore and a paid up capital of BDT 10 (Ten) Crore wherein Advanced Chemical Industries PLC shall hold 85% shares at the earliest convenience subject to the approval of the concerned authority.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2025-02-02</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Q2 Financials</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>(Q2 Un-audited): Consolidated EPS was Tk. (3.17) for October-December 2024 as against Tk. (5.51) for October-December 2023; Consolidated EPS was Tk. (7.99) for July-December 2024 as against Tk. (7.30) for July-December 2023. Consolidated NOCFPS was Tk. (63.58) for July-December 2024 as against Tk. (77.05) for July-December 2023. Consolidated NAV per share was Tk. 68.33 as on December 31, 2024 and Tk. 79.28 as on June 30, 2024.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2025-02-02</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Buy Confirmation of Chairman</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>M. Anis Ud Dowla, Chairman of the Company, has further informed that he has completed his buying of 16,00,000 shares of the company at prevailing market price through Dhaka Stock Exchange PLC. as per declaration disseminated on 26.01.2025.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2025-01-30</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Buy confirmation of Nominated Director</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>Ms. Shusmita Anis, a Nominated Director of the Company, has further informed that she has completed her buying of 1,515,000 shares of the Company at prevailing market price through Dhaka Stock Exchange PLC. as per declaration disseminated on 15.01.2025.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2025-01-26</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Buy Declaration of Chairman</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>Mr. M. Anis Ud Dowla, Chairman of the company, has expressed his intention to buy 1,600,000 shares of the company at prevailing market price (in the Block Market) through Dhaka Stock Exchange PLC. within next 30 (thirty) working days as per Rule 4 of the BSEC (Substantial Acquisition of Shares Rules, 2018).</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2025-01-26</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Dividend Disbursement</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>The Company has informed that it has credited the Bonus Shares for the year ended June 30, 2024 to the respective shareholders' BO Accounts.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2025-01-23</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Board Meeting schedule under LR 16(1)</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>As per Regulation 16(1) of the Dhaka Stock Exchange (Listing) Regulations, 2015, the Company has informed that a meeting of the Board of Directors will be held on January 30, 2025 at 4:00 PM to consider, among others, un-audited financial statements of the Company for the Second Quarter (Q2) period ended December 31, 2024.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2025-01-22</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Buy confirmation of Managing Director</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>Dr. Arif Dowla, Managing Director of the Company, has further informed that he has completed his buying of 6,00,000 shares of the company at prevailing market price through Dhaka Stock Exchange PLC. as per declaration disseminated on 09.01.2025.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2025-01-20</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Buy Declaration of a Director</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>Ms. Shusmita Anis, a Director of the Company, has expressed her intention to buy 1,515,000 shares of the Company at prevailing market price (in the Block Market) through Dhaka Stock Exchange PLC. within next 30 working days.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2025-01-15</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Credit Rating Result</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>Credit Rating Information and Services Limited (CRISL) has assigned the rating of the Company as "AA-" in the long term and "ST-2" in the short term along with Stable outlook in consideration of its audited financials up to June 30, 2024 also unaudited financials up to September 30, 2024 and other relevant quantitative as well as qualitative information up to the date of rating declaration.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2025-01-09</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Buy Declaration of Managing Director</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>Dr. Arif Dowla, Managing Director of the Company, has expressed his intention to buy 6,00,000 shares of the Company at prevailing market price (in the Block Market) through Dhaka Stock Exchange PLC. within next within next 30 working days.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2025-01-09</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Regarding Issuing of Shares and Raising Authorized Capital</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>(Cont. news of ACI): and the authorized share capital of Premiaflex Plastics Limited i.e. BDT 150.00 Crore will be added with the current Authorized Capital of the Company in line with the said order and the article 38 of the Scheme of Amalgamation. Accordingly, the Authorized Capital of Advanced Chemical Industries Limited will now become BDT 300.00 Crore. (end)</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2024-11-19</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Regarding Issuing of Shares and Raising Authorized Capital</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>(Cont. news of ACI): Premiaflex Plastics Limited as per the following table: (Name of the Shareholders - Quantity of Ordinary Shares - Face Value (BDT) - Total Amount of Issued Shares (BDT)): 1. Mr. M anis Ud Dowla - 194,989 shares - Tk. 10.00 - BDT 1,949,890.00; 2. Dr. Arif Dowla - 195 shares - Tk. 10.00 - BDT 1,950.00; 3. Ms. Shusmita Anis - 190 shares - Tk. 10.00 - BDT. 1,900.00 (cont.2)</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2024-11-19</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Regarding Issuing of Shares and Raising Authorized Capital</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>Refer to the earlier news disseminated by DSE on 14.07.2022 regarding arrangement for demerger and merger subject to proper authorities' approval, the company has further informed that, in accordance with that earlier disclosures and Judgment passed in the Company Matter No. 272 of 2022 on 7 November 2023 by the Honorable High Court Division, 195,374 Nos. of ordinary shares of Tk. 10/- (Taka Ten) each only will be issued and allotted in favour of the equity shareholders of (cont.1)</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2024-11-19</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Resumption after Record date</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>Trading of the shares of the company will resume on 18.11.2024.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2024-11-17</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Q1 Financials</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>(Cont. news of ACI): Reasons for deviation: Consolidated EPS decreased as cost of borrowing increased due to the increase in market interest rate along with the additional funding for working capital and strategic investments for supporting business growth. Consolidated NOCFPS has decreased as a result of the movement in the working capital level. (end)</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2024-11-17</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Q1 Financials</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>(Q1 Un-audited): Consolidated EPS was Tk. (5.54) for July-September 2024 as against Tk. (2.07) for July-September 2023; Consolidated NOCFPS was Tk. (62.07) for July-September 2024 as against Tk. (34.19) for July-September 2023. Consolidated NAV per share was Tk. 84.77 as on September 30, 2024 and Tk. 91.17 as on June 30, 2024. (cont.)</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2024-11-17</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Suspension for Record date</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>Trading of the shares of the company will remain suspended on the record date, i.e., 17.11.2024.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2024-11-14</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Spot News</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>Trading of the shares of the company will be allowed only in the Spot Market and Block transaction will also be settled as per spot settlement cycle with cum benefit from 13.11.2024 to 14.11.2024 and trading of the shares will remain suspended on record date i.e., 17.11.2024.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2024-11-12</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Board Meeting schedule under LR 16(1)</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>As per Regulation 16(1) of the Dhaka Stock Exchange (Listing) Regulations, 2015, the Company has informed that a meeting of the Board of Directors will be held on November 14, 2024 at 4:00 PM to consider, among others, un-audited financial statements of the Company for the First Quarter (Q1) period ended September 30, 2024.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2024-11-10</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Dividend Declaration (Additional Information)</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>Refer to their earlier news disseminated today i.e., 29.10.2024 regarding dividend declaration, the company has further informed that the declared dividend has not been recommended from capital reserve or revaluation reserve or any unrealized gain of the company or through reducing the paid-up capital. Bonus shares has been recommended for utilization the retain earnings of the Company as Capital for ongoing operation, i.e. working Capital.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2024-10-29</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Price Limit Open</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>There will be no price limit on the trading of the shares of the Company today (29.10.2024) following its corporate declaration.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2024-10-29</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Dividend Declaration</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>The Board of Directors has recommended 20% Cash and 15% Stock Dividend for the year ended June 30, 2024. Date of AGM: 29.12.2024, Time: 11:30 AM, Venue: Digital System. Record Date: 17.11.2024. The Company has also reported consolidated EPS of Tk. (18.25), consolidated NAV per share of Tk. 91.17 and consolidated NOCFPS of Tk. 0.82 for the year ended June 30, 2024 as against Tk. (6.47), Tk. 113.38 and Tk. (24.44) respectively for the year ended June 30, 2023.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2024-10-29</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2"><hr/></th>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">Trading Code:</th>
+						                    <td>ACI</td>
+						                </tr>
+						                <tr>
+						                    <th>News Title:</th>
+						                    <td>ACI: Board Meeting schedule under LR 19(1)</td>
+						                </tr>
+						                						                <tr>
+						                    <th width="15%">News:</th>
+						                    <td>As per Regulation 19(1) of the Dhaka Stock Exchange (Listing) Regulations, 2015, the Company has informed that a meeting of the Board of Directors will be held on October 28, 2024 at 4:00 PM to consider, among others, audited financial statements of the Company for the year ended June 30, 2024.</td>
+						                </tr>
+						                <tr>
+						                    <th width="15%">Post Date:</th>
+						                    <td>2024-10-21</td>
+						                </tr>
+						                						                <tr>
+						                    <th colspan="2">&nbsp;</th>
+						                </tr>
+						                								</table>								
+							</div>
+						</div>
+					</div>
+					<div class="text-center margin-40"><a href="news_archive.php" class="btn btn-primary">News Archive</a></div>
+                    <style type="text/css" media="print">
+
+.main-signature{
+        display: none;
+    }
+
+</style>
+<div class="main-signature">
+	<div style="text-align:center;" class="signature-class"> 
+		<!-- <img height=53 src="assets/images/dse.gif" width=363 border=0  class="img-responsive center-block" style="margin-top: 20px;"><BR/> -->
+		<img height=53 src="assets/images/dse-plc.gif" width=340 border=0  class="img-responsive center-block" style="margin-top: 20px;"><BR/>
+		DSE Tower, Plot # 46, Road # 21, Nikunja-2, Dhaka-1229, Bangladesh<BR>
+		Phone: +88-02-41040189-200, FAX: +88-02-41040096<BR>
+		Email: <a class='ab1' href="mailto:info@dse.com.bd">info@dse.com.bd</A>, 
+		Web: <a class='ab1' href="http://www.dsebd.org/">http://www.dsebd.org/</A><BR/>&nbsp;
+	</div>
+</div>				</div>
+	      	</div>	      	
+		</section>
+		<div class="clearfix"></div>
+	</div>
+	<!--Containerbox End-->
+	
+	<style type="text/css" media="print">
+
+.containerFot, .containerFotMobile{
+        display: none;
+    }
+
+</style>
+
+<div class="containerFot">
+	<footer>
+		<div class="footerBottom row al-li">
+			<div class="col-2"><a href="disclaimer.htm">Disclaimer</a></div>
+			<div class="col-8">
+				<ul>
+					<li><a href="index.php">Home</a></li>
+					<li><a href="download.php">Download</a></li>
+					<li><a href="data_archive.php">Data Archives</a></li>
+					<li><a href="career.php">Career at DSE</a></li>
+					<li><a href="dse_faq.php">FAQ</a></li>
+					<li><a href="feedback.php">WUF</a></li>
+					<li><a href="sitemap.php">Site Map</a></li>
+					<li><a href="ose.php">Link</a></li>
+				</ul>
+				<p><a href="copyright.htm"><font size="3">&copy;</font> Dhaka Stock Exchange 2020</a></p>
+			<!--	<p>Powered by <a href="http://www.bol-online.com" target="_blank"> Bangladesh Online</a>, a division of Bangladesh Export Import Company Ltd.</p>  -->
+			</div>
+			<div class="col-2"><a href="termsacond.htm">Terms & Condition</a></div>
+		</div>
+	</footer>
+	<div class="clearfix"></div>
+</div>
+
+<div class="containerFotMobile">
+	<footer>
+		<div class="footerBottom row">
+			<div class="col-md-2 col-6"><a href="disclaimer.htm">Disclaimer</a></div>
+			<div class="col-md-2 col-6"><a href="termsacond.htm">Terms &amp; Condition</a></div>
+			<div class="col-md-8 col-12">
+				<ul>
+					<li><a href="index.php">Home</a></li>
+					<li><a href="download.php">Download</a></li>
+					<li><a href="data_archive.php">Data Archives</a></li>
+					<li><a href="career.php">Career at DSE</a></li>
+					<li><a href="dse_faq.php">FAQ</a></li>
+					<li><a href="feedback.php">WUF</a></li>
+					<li><a href="sitemap.php">Site Map</a></li>
+					<li><a href="ose.php">Link</a></li>
+				</ul>
+				
+      			<p><a href="copyright.htm"><font size="3">&copy;</font> Dhaka Stock Exchange 2020</a></p>
+				<!--	<p>Powered by <a href="http://www.bol-online.com" target="_blank"> Bangladesh Online</a>, a division of Bangladesh Export Import Company Ltd.</p> -->
+			</div>
+		</div>
+	</footer>
+	<div class="clearfix"></div>
+</div>
+<link href="assets/lib/scroll/perfect-scrollbar.css" rel="stylesheet">
+
+<!-- <script defer src="assets/js/jquery.min.js"></script> -->
+<!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.0/jquery.min.js" integrity="sha512-b6lGn9+1aD2DgwZXuSY4BhhdrDURVzu7f/PASu4H1i5+CRpEalOOz/HNhgmxZTK9lObM1Q7ZG9jONPYz8klIMg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script> -->
+
+<!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script> -->
+<script src="assets/update/jquery.min.js"></script>
+
+<script defer type="text/javascript" src="assets/js/jquery-ui.js"></script>
+<!-- <script defer type="text/javascript" src="assets/js/bootstrap.js"></script> -->
+
+<!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.1.3/js/bootstrap.min.js" integrity="sha512-OvBgP9A2JBgiRad/mM36mkzXSXaJE9BEIENnVEmeZdITvwT09xnxLtT4twkCa8m/loMbPHsvPl0T8lRGVBwjlQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script> -->
+<script src="assets/update/bootstrap.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+
+<script defer type="text/javascript" src="assets/js/tab.js"></script>
+<script defer src="assets/lib/scroll/perfect-scrollbar.min.js"></script>
+<script defer type="text/javascript" src="assets/js/jquery.floatThead.min.js"></script>
+<script defer type="text/javascript" src="assets/js/jquery.dataTables.min.js"></script>
+<script defer type="text/javascript" src="assets/js/custom.js"></script>
+
+<script type="text/javascript">
+	// $('.carousel').carousel({
+	//   	interval: 3000
+	// });
+
+	$('.collapse-sub').on('shown.bs.collapse-sub', function (e) {
+  		$('.collapse-sub').not(this).removeClass('in');
+	});
+
+	$('[data-toggle=collapse-sub]').click(function (e) {
+	  	$('[data-toggle=collapse-sub]').parent('li').removeClass('active');
+	  	$(this).parent('li').toggleClass('active');
+	});
+
+  	$(function() {
+    	$('#description').perfectScrollbar();
+  	
+  		$(".profiles").find(".tab").hide();
+		$(".profiles").find(".tab").first().show();
+		$(".profiles").find(".tabs li").first().find("a").addClass("active");
+
+		$(".profiles").find(".tabs").find("a").click(function(){
+		    tab = $(this).attr("href");
+		    $(".profiles").find(".tab").hide();
+		    $(".profiles").find(".tabs").find("a").removeClass("active");
+		    $(tab).show();
+		    $(this).addClass("active");
+		    return false;
+		});
+
+		var TradingCode = [];
+		$.get("ajax/suggestList.php", { "suggestType" : "tc" }, function(ret){ 
+			TradingCode = JSON.parse(ret);
+			$( ".textCompany" ).autocomplete({
+				source: TradingCode/*function( request, response ) {
+						var matcher = new RegExp( "^" + $.ui.autocomplete.escapeRegex( request.term ), "i" );
+						response( $.grep( TradingCode, function( item ){
+							return matcher.test( item.label );
+						}) )*/
+			});
+		});
+
+		var TrecHolder = [];
+		$.get("ajax/suggestList.php", { "suggestType" : "th" }, function(ret){ 
+			TrecHolder = JSON.parse(ret);
+			$( ".textTRECHolder" ).autocomplete({
+				source: TrecHolder
+			});
+		});
+	});
+
+	function openNav() {
+		document.getElementById("mySidenav").style.width = "250px";
+	    document.getElementById("RightBody").style.marginLeft = "250px";
+	}
+
+	function closeNav() {
+	    document.getElementById("mySidenav").style.width = "0";
+	    document.getElementById("RightBody").style.marginLeft= "0";
+	}
+
+	function chkform() {
+		if(document.form.name.value == "") {
+	   		alert("Please Enter Specific company symbol or company name");
+	   		document.form.name.focus();
+	   		return false;
+		}
+
+
+	}
+
+(function($){
+	$(document).ready(function(){
+
+		$(".dropdown-submenu").on("click", function(e){
+			//e.preventDefault();
+			e.stopPropagation();
+
+			$(this).toggleClass('open');
+			var dropdown = $(this).find('.dropdown-toggle');
+			if (dropdown.attr('aria-expanded')) {
+				dropdown.removeAttr('aria-expanded');
+			} else {
+				dropdown.attr('aria-expanded', true);
+			};
+		});
+	});
+})(jQuery);
+</script></body>
+</html>
+<script>calculateRightBody();</script>

--- a/tests/test_block_trade_data.py
+++ b/tests/test_block_trade_data.py
@@ -1,0 +1,58 @@
+"""Parser tests for BlockTradeData against saved DSE HTML fixtures."""
+
+import pandas as pd
+import pytest
+
+from stocksurferbd import BlockTradeData, FundamentalData
+
+
+def test_parse_block_trades_dse(market_stats_soup):
+    records = BlockTradeData.parse_block_trades_dse(market_stats_soup)
+    assert len(records) == 54
+
+    first = records[0]
+    assert first["DATE"] == "2026-06-17"
+    assert first["TRADING_CODE"] == "ACFL"
+    assert first["MAX_PRICE"] == 24.50
+    assert first["TRADES"] == 1
+    assert first["QUANTITY"] == 75000
+
+    # Codes with special characters must survive parsing.
+    codes = [r["TRADING_CODE"] for r in records]
+    assert "KAY&QUE" in codes
+
+
+def test_block_trades_df_dtypes(market_stats_soup):
+    records = BlockTradeData.parse_block_trades_dse(market_stats_soup)
+    df = pd.DataFrame(records, columns=BlockTradeData.BLOCK_COLUMNS)
+    assert df.shape == (54, 7)
+    assert df["QUANTITY"].dtype == "int64"
+    assert df["MAX_PRICE"].dtype == "float64"
+
+
+def test_parse_block_trades_missing_section():
+    from bs4 import BeautifulSoup
+    soup = BeautifulSoup("<html><body>no block data</body></html>", "html.parser")
+    with pytest.raises(Exception):
+        BlockTradeData.parse_block_trades_dse(soup)
+
+
+def test_block_trade_news_proxy(monkeypatch, news_soup):
+    # Build the news DataFrame the way get_news_df would, from the fixture.
+    records = FundamentalData.parse_news_rows(news_soup, "ACI")
+    news_df = pd.DataFrame(records, columns=["symbol", "date", "title", "news"])
+
+    monkeypatch.setattr(
+        FundamentalData, "get_news_df", lambda self, symbol, years=2: news_df
+    )
+
+    block_news = BlockTradeData().get_block_trade_news_df("ACI", years=2)
+    assert not block_news.empty
+    assert len(block_news) < len(news_df)  # filtered down to block-related items
+    haystack = (block_news["title"] + " " + block_news["news"]).str.lower()
+    assert haystack.str.contains("block").all()
+
+
+def test_invalid_market_raises():
+    with pytest.raises(IOError):
+        BlockTradeData().get_block_trades_df(market="NYSE")

--- a/tests/test_fundamental_data.py
+++ b/tests/test_fundamental_data.py
@@ -1,0 +1,54 @@
+"""Parser tests for FundamentalData against saved DSE HTML fixtures."""
+
+from stocksurferbd import FundamentalData
+
+
+def test_parse_company_meta(company_soup):
+    meta = FundamentalData.parse_company_meta(company_soup)
+    assert meta["company_name"] == "Advanced Chemical Industries PLC"
+    assert meta["website"] == "http://www.aci-bd.com"
+    assert "Tejgaon" in meta["address"]
+    assert meta["financial_statement_link"].startswith("http")
+    assert meta["price_sensitive_info_link"].startswith("http")
+
+
+def test_parse_company_meta_never_raises_on_blank():
+    from bs4 import BeautifulSoup
+    soup = BeautifulSoup("<html><body>nothing here</body></html>", "html.parser")
+    meta = FundamentalData.parse_company_meta(soup)
+    # Missing fields fall back to '-' instead of raising.
+    assert meta["company_name"] == "-"
+    assert meta["website"] == "-"
+
+
+def test_append_company_backward_compatible(company_soup):
+    dict_company, _ = FundamentalData.parse_company_data_rows(company_soup, "ACI")
+
+    df_old = FundamentalData.append_company(
+        dict_company["company_info"], dict_company["fin_interim_info"], "ACI"
+    )
+    meta = FundamentalData.parse_company_meta(company_soup)
+    df_new = FundamentalData.append_company(
+        dict_company["company_info"], dict_company["fin_interim_info"], "ACI", meta=meta
+    )
+
+    # Existing behaviour preserved, new columns purely additive at the end.
+    assert df_old.columns[0] == "symbol"
+    assert len(df_new.columns) == len(df_old.columns) + len(meta)
+    assert list(df_new.columns[: len(df_old.columns)]) == list(df_old.columns)
+    assert df_new.iloc[0]["company_name"] == "Advanced Chemical Industries PLC"
+
+
+def test_parse_news_rows(news_soup):
+    records = FundamentalData.parse_news_rows(news_soup, "ACI")
+    assert len(records) == 79
+    first = records[0]
+    assert set(first.keys()) == {"symbol", "date", "title", "news"}
+    assert first["symbol"] == "ACI"
+    assert all(r["date"] for r in records)
+
+
+def test_parse_news_rows_no_table():
+    from bs4 import BeautifulSoup
+    soup = BeautifulSoup("<html><body>no news</body></html>", "html.parser")
+    assert FundamentalData.parse_news_rows(soup, "ACI") == []


### PR DESCRIPTION
## Summary
Extends `stocksurferbd` with new fundamental/market data, fully backward compatible (existing methods, signatures and the two original company files are unchanged).

### Company identity & links (new columns on `<symbol>_company_data.xlsx`)
`company_name`, `website`, `address`, `financial_statement_link`, `price_sensitive_info_link` — extracted via label-based lookups, appended at the end so existing column positions are unchanged.

### Company news — `FundamentalData.get_news_df` / `save_news_data`
Per-company news from the DSE news archive over a rolling N-year window (default 2; `years=None` = all). Output: `<symbol>_news_data.xlsx` with `symbol, date, title, news`.

### Block trades — new `BlockTradeData` class
- `get_block_trades_df` / `save_block_trade_data` — real current-day block transactions from `market-statistics.php` (all symbols): `DATE, TRADING_CODE, MAX_PRICE, MIN_PRICE, TRADES, QUANTITY, VALUE_MN`. DSE has no historical block archive, so run daily to accumulate.
- `get_block_trade_news_df` / `save_block_trade_news_data` — per-company block-market disclosures (filtered view of the news feed).

### Infrastructure
- New `HttpScraper` base with optional `verify` / `session` / `timeout` (handles DSE's incomplete TLS chain in some environments); defaults preserve existing behaviour.
- Shared `parse_float` / `parse_int` in `utils.py`.
- pytest suite with committed DSE HTML fixtures (10 tests).
- Version bumped to **1.0.0**; README documents the new methods and full output schema.

## Verification
- 10/10 unit tests pass against fixtures.
- End-to-end live (with `verify=False`): current prices (396), ACI history (473), company data (1 row, all 5 new columns), financial (5), news (79), block trades today (54), block-news proxy (13), and `CandlestickPlot` still renders.
- Also fixed a pre-existing README bug (`csv_path` → `file_path` in the CandlestickPlot example).

🤖 Generated with [Claude Code](https://claude.com/claude-code)